### PR TITLE
Change Ecto.Type to use map

### DIFF
--- a/lib/money/ecto/money_ecto_type.ex
+++ b/lib/money/ecto/money_ecto_type.ex
@@ -1,46 +1,42 @@
 defmodule Money.Ecto.Type do
   @moduledoc """
-  Implements the Ecto.Type behaviour for a user-defined Postgres composite type
-  called `:money_with_currency`.
+  Implements Ecto.Type behaviour for Money, where the underlying schema type
+  is a map.
   """
 
   if Code.ensure_loaded?(Ecto.Type) do
     @behaviour Ecto.Type
 
-    def type do
-      :money_with_currency
+    def type(), do: :map
+
+    def cast(%{"currency" => currency, "amount" => term})
+    when is_binary(currency) and is_binary(term) do
+      with {:ok, amount} <- Decimal.parse(term) do
+        {:ok, Money.new(currency, amount)}
+      end
     end
 
-    def blank?(_) do
-      false
+    def cast(%{"currency" => currency, "amount" => term})
+    when is_binary(currency) and is_number(term) do
+      with {:ok, amount} <- Decimal.new(term) do
+        {:ok, Money.new(currency, amount)}
+      end
     end
 
-    def load(money) do
-      {:ok, Money.new(money)}
+    def cast(%Money{} = money), do: {:ok, money}
+    def cast(_), do: :error
+
+    def load(%{"currency" => currency, "amount" => term}) do
+      with {:ok, amount} <- Decimal.parse(term) do
+        {:ok, Money.new(currency, amount)}
+      end
     end
 
-    def dump(%Money{} = money) do
-      {:ok, {to_string(money.currency), money.amount}}
+    def dump(%Money{currency: currency,
+                    amount: %Decimal{} = amount}) do
+      {:ok, %{currency: currency,
+              amount: Decimal.to_string(amount)}}
     end
-
-    def dump(money) when is_tuple(money) do
-      {:ok, money}
-    end
-
-    def dump(_) do
-      :error
-    end
-
-    def cast(%Money{} = money) do
-      {:ok, money}
-    end
-
-    def cast(money) when is_tuple(money) do
-      {:ok,  Money.new(money)}
-    end
-
-    def cast(_money) do
-      :error
-    end
+    def dump(_), do: :error
   end
 end


### PR DESCRIPTION
There are several advantages to maps.

1. MySQL doesn't support composite types, with no plans to do so.
2. Most databases (if not all latest versions) have JSON support, which is a `:map` in Ecto.
3. Most popular databases are optimised to extract data from JSON, so it's not too different from a composite type.
4. Storing `Decimal` as a string gives precision and scale not bound by database nor bit-width, but by `Decimal.to_string`. 

One downside is additional space taken for something that doesn't need to be schemaless. However in my opinion, it's a worthwhile trade-off to work seamlessly with all databases.

I see this as a quickstart module for using Money with Ecto. I suspect in most real-world code, data will be accessed from legacy databases to create Money structs for formatting and arithmetic only.

In addition, I've added casting `%{"currency" => currency, "amount" => amount}` to `%Money{}`, where `amount` can be a string or number.

This makes it convenient to use with `Ecto.Changeset`.