### PR TITLE
Configure components at runtime

### DIFF
--- a/lib/money/exchange_rates/exchange_rates.ex
+++ b/lib/money/exchange_rates/exchange_rates.ex
@@ -71,8 +71,7 @@ defmodule Money.ExchangeRates do
   called periodically by `Money.ExchangeRates.Retriever.handle_info/2` but can
   called at any time by other functions.
   """
-  @exchange_rate_api Money.get_env(:api_module, Money.ExchangeRates.OpenExchangeRates)
   def get_latest_rates do
-    @exchange_rate_api.get_latest_rates()
+    Money.get_env(:api_module, Money.ExchangeRates.OpenExchangeRates).get_latest_rates()
   end
 end

--- a/lib/money/exchange_rates/exchange_rates_retriever.ex
+++ b/lib/money/exchange_rates/exchange_rates_retriever.ex
@@ -16,78 +16,83 @@ defmodule Money.ExchangeRates.Retriever do
   """
 
   use GenServer
+
+  require Logger
+
   @default_retrieval_interval 360_000
-  @retrieve_every Money.get_env(:exchange_rates_retrieve_every, @default_retrieval_interval)
-
   @default_callback_module Money.ExchangeRates.Callback
-  @callback_module Money.get_env(:callback_module, @default_callback_module)
 
-   def start_link(name) do
-     GenServer.start_link(__MODULE__, [], name: name)
-   end
+  defmodule Config do
+    defstruct retrieve_every: nil,
+              callback_module: nil,
+              log_levels: %{}
+  end
 
-   def init([]) do
-     require Logger
+  def start_link(name) do
+    state = %Config{
+      retrieve_every: Money.get_env(:exchange_rates_retrieve_every, @default_retrieval_interval),
+      callback_module: Money.get_env(:callback_module, @default_callback_module),
+      log_levels: %{
+        success: Money.get_env(:log_success, nil),
+        info: Money.get_env(:log_info, :warn),
+        failure: Money.get_env(:log_failure, :warn)
+      }
+    }
 
-     log(:info, "Starting exchange rate retrieval service")
-     log(:info, "Rates will be retrieved every #{div(@retrieve_every, 1000)} seconds.")
+    GenServer.start_link(__MODULE__, state, name: name)
+  end
+
+   def init(state) do
+     log(state, :info, "Starting exchange rate retrieval service")
+     log(state, :info, "Rates will be retrieved every #{div(state.retrieve_every, 1000)} seconds.")
+
      initialize_ets_table()
-     do_retrieve_rates()
-     schedule_work()
-     {:ok, []}
+
+     do_retrieve_rates(state)
+     schedule_work(state.retrieve_every)
+
+     {:ok, state}
    end
 
-   def handle_info(:latest, _state) do
-     state = do_retrieve_rates()
-     schedule_work()
+   def handle_info(:latest, state) do
+     do_retrieve_rates(state)
+     schedule_work(state.retrieve_every)
      {:noreply, state}
    end
 
-   def do_retrieve_rates do
-     case Money.ExchangeRates.get_latest_rates() do
-       {:ok, rates} ->
-         retrieved_at = DateTime.utc_now
-         :ets.insert(:exchange_rates, {:rates, rates})
-         :ets.insert(:exchange_rates, {:last_updated, retrieved_at})
-         apply(@callback_module, :rates_retrieved, [rates, retrieved_at])
-         log(:success, "Retrieved exchange rates successfully")
-       {:error, reason} ->
-         log(:failure, "Error retrieving exchange rates: #{inspect reason}")
-     end
-   end
+  def do_retrieve_rates(%{callback_module: callback_module} = state) do
+    case Money.ExchangeRates.get_latest_rates() do
+      {:ok, rates} ->
+        retrieved_at = DateTime.utc_now
+        store_rates(rates, retrieved_at)
+        apply(callback_module, :rates_retrieved, [rates, retrieved_at])
+        log(state, :success, "Retrieved exchange rates successfully")
+      {:error, reason} ->
+        log(state, :failure, "Error retrieving exchange rates: #{inspect reason}")
+    end
+    state
+  end
 
-   defp schedule_work do
-     Process.send_after(self(), :latest, @retrieve_every)
-   end
+  defp schedule_work(delay_ms) do
+    Process.send_after(self(), :latest, delay_ms)
+  end
 
-   defp initialize_ets_table do
-     :ets.new(:exchange_rates, [:named_table, read_concurrency: true])
-   end
+  defp initialize_ets_table do
+    :ets.new(:exchange_rates, [:named_table, read_concurrency: true])
+  end
 
-   @success_level Money.get_env(:log_success, nil)
-   defp log(:success, message) do
-     require Logger
+  defp store_rates(rates, retrieved_at) do
+    :ets.insert(:exchange_rates, {:rates, rates})
+    :ets.insert(:exchange_rates, {:last_updated, retrieved_at})
+  end
 
-     if not is_nil(@success_level) do
-       Logger.log(@success_level, message)
-     end
-   end
+  defp log(%{log_levels: log_levels}, key, message) do
+    case Map.get(log_levels, key) do
+      nil ->
+        nil
+      log_level ->
+        Logger.log(log_level, message)
+    end
+  end
 
-   @info_level Money.get_env(:log_info, :warn)
-   defp log(:info, message) do
-     require Logger
-
-     if not is_nil(@info_level) do
-       Logger.log(@info_level, message)
-     end
-   end
-
-   @failure_level Money.get_env(:log_failure, :warn)
-   defp log(:failure, message) do
-     require Logger
-
-     if not is_nil(@failure_level) do
-       Logger.log(@failure_level, message)
-     end
-   end
  end

--- a/lib/money/exchange_rates/open_exchange_rates.ex
+++ b/lib/money/exchange_rates/open_exchange_rates.ex
@@ -1,10 +1,6 @@
 defmodule Money.ExchangeRates.OpenExchangeRates do
   @behaviour Money.ExchangeRates
 
-  @dummy_app_id "not_configured"
-  @app_id  Money.get_env(:open_exchange_rates_app_id, @dummy_app_id)
-  @exr_url Money.get_env(:open_exchange_rates_url, "https://openexchangerates.org/api")
-
   @doc """
   Retrieves the latest exchange rates from Open Exchange Rates site.
 
@@ -21,29 +17,26 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
   service althouhg it can be called outside that context as
   required.
   """
-  @latest_endpoint "/latest.json"
-  @latest_url @exr_url <> @latest_endpoint <> "?app_id="
-  @spec get_latest_rates(String.t) :: {:ok, Map.t} | {:error, String.t}
-  def get_latest_rates(app_id \\ @app_id)
 
-  def get_latest_rates(@dummy_app_id) do
+  @dummy_app_id "not_configured"
+
+  @spec get_latest_rates(String.t) :: {:ok, Map.t} | {:error, String.t}
+  def get_latest_rates(app_id \\ @dummy_app_id) do
+    url    = Money.get_env(:open_exchange_rates_url, "https://openexchangerates.org/api")
+    app_id = Money.get_env(:open_exchange_rates_app_id, app_id)
+
+    get_rates(url, app_id)
+  end
+
+  defp get_rates(_url, @dummy_app_id) do
     {:error, "Open Exchange Rates app_id is not configured.  Rates are not retrieved."}
   end
-
-  def get_latest_rates(app_id) do
-    get_rates(@latest_url, app_id)
+  defp get_rates(url, app_id) do
+    get_rates(url <> "/latest.json?app_id=" <> app_id)
   end
 
-  defp get_rates(url, app_id) when is_binary(url) do
-    url <> app_id
-    |> String.to_char_list
-    |> get_rates
-  end
-
-  defp get_rates(url) when is_list(url) do
-    require Logger
-
-    case :httpc.request(url) do
+  defp get_rates(url) do
+    case :httpc.request(String.to_char_list(url)) do
       {:ok, {{_version, 200, 'OK'}, _headers, body}} ->
         %{"base" => _base, "rates" => rates} = Poison.decode!(body)
 


### PR DESCRIPTION
This PR addresses an issue with the handling of configuration values set in the OTP application environment.

In various places, the current implementation assigns configuration values (via `Application.get_env` wrapped in `Money.get_env`) to module attributes. These bindings occur at **compile-time**. 
This is a significant issue because the configuration will effectively be frozen in the dependency the first time it's compiled into a project. Any change to the `:ex_money` configuration from the main project `config.exs` will be silently ignored until the dependency is cleaned and rebuilt.

This change removes all uses of module attributes to store configuration values and replaces them with either direct calls to `Money.get_env` or, in the case of the `ExchangeRateRetriever` module, stores the configuration in the GenServer state to have it readily available to all callbacks.
Incidentally, I've also simplified the handling of configurable log levels in the GenServer thanks to this new data structure.

While I believe that a more idiomatic approach would be to go one step further and inject the GenServer configuration from the Supervisor via `start_link` arguments, I wanted to keep this first refactoring limited to the components affected by this particular issue.