### PR TITLE
Start :inets before Money

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Money.Mixfile do
   def application do
     [
       mod: {Money, []},
-      applications: [:logger]
+      extra_applications: [:inets, :logger]
     ]
   end
 


### PR DESCRIPTION
I had trouble getting Money to start in a release version:

the default exchange rate service synchronously calls :httpc.request/1 on start
which requires :httpc_manager to be started, which is started by :inets.