### PR TITLE
Allow to cast maps with atom keys

### DIFF
--- a/lib/money/ecto/money_ecto_composite_type.ex
+++ b/lib/money/ecto/money_ecto_composite_type.ex
@@ -77,6 +77,10 @@ defmodule Money.Ecto.Composite.Type do
       end
     end
 
+    def cast(%{currency: currency, amount: amount}) do
+      cast(%{"currency" => currency, "amount" => amount})
+    end
+
     def cast(_money) do
       :error
     end

--- a/lib/money/ecto/money_ecto_map_type.ex
+++ b/lib/money/ecto/money_ecto_map_type.ex
@@ -36,6 +36,10 @@ defmodule Money.Ecto.Map.Type do
       end
     end
 
+    def cast(%{currency: currency, amount: amount}) do
+      cast(%{"currency" => currency, "amount" => amount})
+    end
+
     def cast(%Money{} = money) do
       {:ok, money}
     end

--- a/test/money_ecto_test.exs
+++ b/test/money_ecto_test.exs
@@ -34,8 +34,37 @@ defmodule MoneyTest.Ecto do
     assert Money.Ecto.Composite.Type.cast %{"currency" => "USD", "amount" => 100} == Money.new(:USD, 100)
   end
 
+  test "cast a map with string keys, atom currency, and string amount" do
+    assert Money.Ecto.Composite.Type.cast %{"currency" => :USD, "amount" => "100"} == Money.new(100, :USD)
+  end
+
+  test "cast a map with string keys, atom currency, and numeric amount" do
+    assert Money.Ecto.Composite.Type.cast %{"currency" => :USD, "amount" => 100} == Money.new(100, :USD)
+  end
+
   test "cast a map with string keys and invalid currency" do
     assert Money.Ecto.Composite.Type.cast(%{"currency" => "AAA", "amount" => 100}) ==
+    {:error, {Cldr.UnknownCurrencyError, "Currency \"AAA\" is not known"}}
+  end
+
+  test "cast a map with atom keys and values" do
+    assert Money.Ecto.Composite.Type.cast %{currency: "USD", amount: "100"} == Money.new(100, :USD)
+  end
+
+  test "cast a map with atom keys and numeric amount" do
+    assert Money.Ecto.Composite.Type.cast %{currency: "USD", amount: 100} == Money.new(100, :USD)
+  end
+
+  test "cast a map with atom keys, atom currency, and numeric amount" do
+    assert Money.Ecto.Composite.Type.cast %{currency: :USD, amount: 100} == Money.new(100, :USD)
+  end
+
+  test "cast a map with atom keys, atom currency, and string amount" do
+    assert Money.Ecto.Composite.Type.cast %{currency: :USD, amount: "100"} == Money.new(100, :USD)
+  end
+
+  test "cast a map with atom keys and invalid currency" do
+    assert Money.Ecto.Composite.Type.cast(%{currency: "AAA", amount: 100}) ==
     {:error, {Cldr.UnknownCurrencyError, "Currency \"AAA\" is not known"}}
   end
 


### PR DESCRIPTION
Ecto changesets allow you to cast maps with either string or atom keys,
so just adding that ability here to match.