### PR TITLE
Prefix Money to Subscription exception modules

### DIFF
--- a/lib/money/exception.ex
+++ b/lib/money/exception.ex
@@ -30,7 +30,7 @@ defmodule Money.Invalid do
   end
 end
 
-defmodule Subscription.NoCurrentPlan do
+defmodule Money.Subscription.NoCurrentPlan do
   defexception [:message]
 
   def exception(message) do
@@ -38,7 +38,7 @@ defmodule Subscription.NoCurrentPlan do
   end
 end
 
-defmodule Subscription.PlanError do
+defmodule Money.Subscription.PlanError do
   defexception [:message]
 
   def exception(message) do
@@ -46,7 +46,7 @@ defmodule Subscription.PlanError do
   end
 end
 
-defmodule Subscription.DateError do
+defmodule Money.Subscription.DateError do
   defexception [:message]
 
   def exception(message) do
@@ -54,7 +54,7 @@ defmodule Subscription.DateError do
   end
 end
 
-defmodule Subscription.PlanPending do
+defmodule Money.Subscription.PlanPending do
   defexception [:message]
 
   def exception(message) do


### PR DESCRIPTION
I got following error while playing around `Money.Subscription` functions.

```elixir
iex(17)> Money.Subscription.change_plan!(s, new, current_interval_started: ~D[2018-01-01]) |>  Money.Subscription.change_plan!(current, current_interval_started: ~D[2018-09-01])
** (UndefinedFunctionError) function Money.Subscription.PlanPending.exception/1 is undefined (module Money.Subscription.PlanPending is not available)
    Money.Subscription.PlanPending.exception("Can't change plan when a new plan is already pending")
    (ex_money) lib/money/subscription.ex:660: Money.Subscription.change_plan!/3
```

This is not desired behavior and these exceptions have to have `Money` prefix. Please correct me if I misunderstood. thanks.

(Tests have been passed due to [this `alias`](https://github.com/kipcole9/money/blob/1eeb1a6769bea2e304cae0a07bf102343c1762c5/test/subscription_test.exs#L5) so far?)
