### PR TITLE
Fix behaviour and typespec of last_updated/0

### DIFF
--- a/lib/money/exchange_rates.ex
+++ b/lib/money/exchange_rates.ex
@@ -294,11 +294,8 @@ defmodule Money.ExchangeRates do
         utc_offset: 0, year: 2016, zone_abbr: "UTC"}}
 
   """
-  @spec last_updated() :: {:ok, DateTime.t()} | nil
+  @spec last_updated() :: {:ok, DateTime.t()} | {:error, {Exception.t(), binary}}
   def last_updated do
-    case cache().last_updated() do
-      {:ok, last_updated} -> {:ok, last_updated}
-      _ -> nil
-    end
+    cache().last_updated()
   end
 end

--- a/lib/money/exchange_rates/cache/exchange_rates_cache_etsdets.ex
+++ b/lib/money/exchange_rates/cache/exchange_rates_cache_etsdets.ex
@@ -34,7 +34,7 @@ defmodule Money.ExchangeRates.Cache.EtsDets do
             {:error, {Money.ExchangeRateError, "Last updated date is not known"}}
 
           last_updated ->
-            last_updated
+            {:ok, last_updated}
         end
       end
 

--- a/test/money_exchange_rates_test.exs
+++ b/test/money_exchange_rates_test.exs
@@ -110,4 +110,11 @@ defmodule Money.ExchangeRates.Test do
     Money.ExchangeRates.default_config()
     |> Money.ExchangeRates.Retriever.reconfigure()
   end
+
+  test "that the last_udpated timestamp is returned in a success tuple" do
+    # warm up cache
+    Money.ExchangeRates.Retriever.latest_rates()
+
+    assert {:ok, %DateTime{}} = Money.ExchangeRates.last_updated()
+  end
 end


### PR DESCRIPTION
The current implementation of `Money.ExchangeRates.last_updated/0` keeps returning `nil` as it expects the cache to return an `{:ok, %DateTime{}}` tuple but it actually returns a `%DateTime{}`.

In addition, the documentation, typespec and implementation all disagree on the return type of this function.  This PR fixes both the implementation and typespec to align with the documented behaviour.

The cache layer now returns `{:ok, %DateTime{}}` or `{:error, reason}` tuples which are forwarded to the caller in the facade module.