### PR TITLE
Set aggregate function to not be called with NULL values

### DIFF
--- a/priv/SQL/postgres/define_aggregate_functions.sql
+++ b/priv/SQL/postgres/define_aggregate_functions.sql
@@ -1,6 +1,7 @@
 CREATE OR REPLACE FUNCTION money_state_function(agg_state money_with_currency, money money_with_currency)
 RETURNS money_with_currency
 IMMUTABLE
+STRICT
 LANGUAGE plpgsql
 AS $$
   DECLARE


### PR DESCRIPTION
#88 

Seems like that already does it: 

> The above definition of sum will return zero (the initial state value) if there are no nonnull input values. Perhaps we want to return null in that case instead — the SQL standard expects sum to behave that way. We can do this simply by omitting the initcond phrase, so that the initial state value is null. Ordinarily this would mean that the sfunc would need to check for a null state-value input. But for sum and some other simple aggregates like max and min, it is sufficient to insert the first nonnull input value into the state variable and then start applying the transition function at the second nonnull input value. PostgreSQL will do that automatically if the initial state value is null and the transition function is marked "strict" (i.e., not to be called for null inputs).

https://www.postgresql.org/docs/9.5/xaggr.html