### PR TITLE
Fix terminate with unhandled reason

### DIFF
--- a/lib/money/exchange_rates/exchange_rates_retriever.ex
+++ b/lib/money/exchange_rates/exchange_rates_retriever.ex
@@ -295,7 +295,7 @@ defmodule Money.ExchangeRates.Retriever do
   end
 
   @doc false
-  def termina(other, _config) do
+  def terminate(other, _config) do
     Logger.error("[ExchangeRates.Retriever] Terminate called with unhandled #{inspect(other)}")
   end
 


### PR DESCRIPTION
Fixes a typo in the fallback function definition for `Money.ExchangeRates.Retriever.terminate/2`