### PR TITLE
Make Money.to_string! actually raise if there is an error

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -610,6 +610,7 @@ defmodule Money do
       {:ok, "1,234 US dollars"}
 
   """
+  @spec to_string(Money.t(), Keyword.t()) :: {:ok, String.t()} | {:error, term}
   def to_string(%Money{} = money, options \\ []) do
     default_options = [backend: Money.default_backend(), currency: money.currency]
     options = Keyword.merge(default_options, options)
@@ -655,6 +656,7 @@ defmodule Money do
       "1,234 US dollars"
 
   """
+  @spec to_string!(Money.t(), Keyword.t()) :: String.t()
   def to_string!(%Money{} = money, options \\ []) do
     with {:ok, string} <- Money.to_string(money, options) do
       string

--- a/lib/money.ex
+++ b/lib/money.ex
@@ -658,6 +658,12 @@ defmodule Money do
   def to_string!(%Money{} = money, options \\ []) do
     with {:ok, string} <- Money.to_string(money, options) do
       string
+    else
+      {:error, {type, message}} when is_atom(type) and is_binary(message) ->
+        raise type, message
+
+      other ->
+        raise "Error converting money to string: " <> inspect(other)
     end
   end
 

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -180,6 +180,19 @@ defmodule MoneyTest do
     assert Money.to_string(money) == {:ok, "$1,234.00"}
   end
 
+  test "to_string works via protocol" do
+    money = Money.new(1234, :USD)
+    assert to_string(money) == "$1,234.00"
+  end
+
+  test "to_string! raises if there is an error" do
+    money = Money.new(1234, :USD)
+
+    assert_raise Cldr.FormatCompileError, fn ->
+      Money.to_string!(money, format: "0#")
+    end
+  end
+
   test "adding two money structs with same currency" do
     assert Money.add!(Money.new(:USD, 100), Money.new(:USD, 100)) == Money.new(:USD, 200)
   end


### PR DESCRIPTION
Hi @kipcole9, I was reading the code and found that `to_string!` doesn't fail in case `to_string` returns an error tuple. Instead, it just returns the error tuple.

Wrote a test that confirmed that, and made `to_string!` raise Cldr exceptions.

However, I couldn't write a test that reaches the more generic clause, as I don't know if it can return an error different than `{:error, {cldr_error_type, message}}`.