### PR TITLE
Parse negative numbers.

### DIFF
--- a/test/money_parse_test.exs
+++ b/test/money_parse_test.exs
@@ -37,6 +37,13 @@ defmodule MoneyTest.Parse do
       assert Money.parse("99.99€") == Money.new(:EUR, "99.99")
     end
 
+    test "parses negative amounts" do
+      assert Money.parse("-100 USD") == Money.new(:USD, -100)
+      assert Money.parse("-USD 100") == Money.new(:USD, -100)
+      assert Money.parse("USD -100") == Money.new(:USD, -100)
+      assert Money.parse("USD -100.00") == Money.new(:USD, "-100.00")
+    end
+
     test "currency filtering" do
       assert Money.parse("100 Mexican silver pesos") == Money.new(:MXP, 100)
 


### PR DESCRIPTION
Hi @kipcole9 ,

Thanks for an amazing library! I've run into needing just simple parsing of negative money amounts, and couldn't figure out an elegant way of doing it, other than tinkering with the internals of the lib.

Let me know what your thoughts are regarding adding this. If you feel it's outside the scope of the library, I would be grateful for some pointers on how to add this as a custom Cldr backend.

✅ Tests run.
✅ New tests added covering negative numbers.
✅ Formatted with `mix format` (there are some other files that weren't correctly formatted, but they aren't related to the code I touched).
