### PR TITLE
Make nimble_parsec a required dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -88,7 +88,7 @@ defmodule Money.Mixfile do
       {:cldr_utils, "~> 2.6"},
       {:decimal, "~> 1.6 or ~> 2.0"},
       {:phoenix_html, "~> 2.0", optional: true},
-      {:nimble_parsec, "~> 0.5", optional: true},
+      {:nimble_parsec, "~> 0.5"},
       {:dialyxir, "~> 1.0.0-rc", only: [:dev], runtime: false},
       {:jason, "~> 1.0", optional: true},
       {:stream_data, "~> 0.4.1", only: [:dev, :test]},


### PR DESCRIPTION
At the moment, adding ex_money 5.0 to a project doesn't compile:

```
== Compilation error in file lib/money/parser.ex ==
** (CompileError) lib/money/parser.ex:4: module NimbleParsec is not loaded and could not be found
```