### PR TITLE
Add :name config option to Supervisor

### DIFF
--- a/lib/money/application.ex
+++ b/lib/money/application.ex
@@ -10,7 +10,8 @@ defmodule Money.Application do
       Money.ExchangeRates.Supervisor
     ]
 
-   supervisor = Supervisor.start_link(children, strategy: :one_for_one)
+    opts = [strategy: :one_for_one, name: Money.Supervisor]
+    supervisor = Supervisor.start_link(children, opts)
 
     if start_exchange_rate_service?() do
       ExchangeRates.Supervisor.start_retriever()


### PR DESCRIPTION
When starting Money.ExchangeRate.Supervisor with the `:restart` option, the supervisor is expected to be named. The option was dropped in v5.0.2 but is still required.

I'm not sure if this was deleted on purpose, or if it seemed obsolete.

Thanks! We love `ex_money` :)