### PR TITLE
Allow Options struct in `to_string!/2` too and document it

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -664,7 +664,7 @@ defmodule Money do
   * `money` is any valid `Money.t` type returned
     by `Money.new/2`
 
-  * `options` is a keyword list of options
+  * `options` is a keyword list of options or a `%Cldr.Number.Format.Options{}` struct
 
   ## Returns
 
@@ -742,7 +742,7 @@ defmodule Money do
   * `money` is any valid `Money.t` type returned
     by `Money.new/2`
 
-  * `options` is a keyword list of options
+  * `options` is a keyword list of options or a `%Cldr.Number.Format.Options{}` struct
 
   ## Options
 
@@ -766,7 +766,8 @@ defmodule Money do
       "1,234 US dollars"
 
   """
-  @spec to_string!(Money.t(), Keyword.t()) :: String.t() | no_return()
+  @spec to_string!(Money.t(), Keyword.t() | Cldr.Number.Format.Options.t()) :: 
+          String.t() | no_return()
 
   def to_string!(%Money{} = money, options \\ []) do
     case to_string(money, options) do


### PR DESCRIPTION
This PR is part of a series of PRs that aim to improve performance by allowing both `%Cldr.Number.Format.Options{}` structs to be passed as options in place of keyword lists, and to add support for `%Cldr.Currency{}` structs as alternative for currency codes.

https://github.com/elixir-cldr/cldr_currencies/pull/4
https://github.com/elixir-cldr/cldr_numbers/pull/18
https://github.com/kipcole9/money/pull/127 (this PR)

Support for precompiled option structs was added before, but not to the `to_string!/2` function, and this PR aims to add this in both documentation and in typespecs.