### PR TITLE
Fix to integer exp

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -1929,7 +1929,7 @@ defmodule Money do
     digits = digits_from_opts(currency, opts[:currency_digits])
     exponent = -digits
     exponent_adjustment = Kernel.abs(exponent - new_money.amount.exp)
-    integer = Cldr.Math.power_of_10(exponent_adjustment) * new_money.amount.coef
+    integer = Cldr.Math.power_of_10(exponent_adjustment) * new_money.amount.coef * new_money.amount.sign
 
     {money.currency, integer, exponent, remainder}
   end

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -495,6 +495,10 @@ defmodule MoneyTest do
     assert Money.to_integer_exp(Money.new(:COP, 1234), currency_digits: :accounting) ==
              {:COP, 123_400, -2, Money.new(:COP, 0)}
   end
+  
+  test "that to_integer_exp handles negative amounts" do
+    assert Money.to_integer_exp(Money.new(:USD, -1234)) == {:USD, -123_400, -2, Money.new(:USD, 0)}
+  end
 
   test "json encoding for Jason" do
     assert Jason.encode(


### PR DESCRIPTION
Hi! First off wanted to thank you for a wonderful library and really appreciate your work ❤️!! 

I think I found a bug with `to_integer_exp/2` and this PR resolves the issue I was seeing. If `to_integer_exp/2` shouldn't handle negative values, I can update this to instead document that and maybe add a spec. But my gut tells me it should. I've added a new test case as well.