### PR TITLE
Improve nan and inf handling

### DIFF
--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -129,22 +129,19 @@ defmodule MoneyTest do
 
   test "that creating a money with a NaN is invalid" do
     assert Money.new(:USD, "NaN") ==
-      {:error,
-       {Money.UnknownCurrencyError, "Invalid money amount. Found #Decimal<NaN>."}}
+             {:error, {Money.InvalidAmountError, "Invalid money amount. Found #Decimal<NaN>."}}
 
     assert Money.new(:USD, "-NaN") ==
-      {:error,
-       {Money.UnknownCurrencyError, "Invalid money amount. Found #Decimal<-NaN>."}}
+             {:error, {Money.InvalidAmountError, "Invalid money amount. Found #Decimal<-NaN>."}}
   end
 
   test "that creating a money with a Inf is invalid" do
     assert Money.new(:USD, "Inf") ==
-      {:error,
-       {Money.UnknownCurrencyError, "Invalid money amount. Found #Decimal<Infinity>."}}
+             {:error, {Money.InvalidAmountError, "Invalid money amount. Found #Decimal<Infinity>."}}
 
     assert Money.new(:USD, "-Inf") ==
-      {:error,
-       {Money.UnknownCurrencyError, "Invalid money amount. Found #Decimal<-Infinity>."}}
+             {:error,
+              {Money.InvalidAmountError, "Invalid money amount. Found #Decimal<-Infinity>."}}
   end
 
   test "that creating a money with a string amount that is invalid returns and error" do


### PR DESCRIPTION
Decimal updated their NaN handling between 1.0 and 2.0 – `:qNaN` and `:sNaN` became just `:NaN`. Using `Decimal.nan?/1` seems to be univerally supported though. 

I also updated the error module to be in line with the error message.