### PR TITLE
Add simplified `Money.ExchangeRatesLite`

### DIFF
--- a/lib/money/exchange_rates_lite.ex
+++ b/lib/money/exchange_rates_lite.ex
@@ -1,0 +1,151 @@
+defmodule Money.ExchangeRatesLite do
+  @moduledoc """
+  Defines a module which retrieves exchange rates from exchange rate services.
+
+  ## Usage
+
+  When used, the module expects `:otp_app` as an option, the `:otp_app` should point to
+  an OTP application that holds related configuration. For example:
+
+      defmodule MyApp.ExchangeRates do
+        use Money.ExchangeRatesLite, otp_app: :my_app
+      end
+
+  Could be configured with:
+
+      config :my_app, MyApp.ExchangeRates,
+        adapter: Money.ExchangeRatesLite.Adapter.OpenExchangeRates,
+        adapter_options: [
+          app_id: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        ]
+
+  Per module configuration is also supported:
+
+      defmodule MyApp.ExchangeRates do
+        use Money.ExchangeRatesLite,
+          otp_app: :my_app,
+          adapter: Money.ExchangeRatesLite.Adapter.OpenExchangeRates,
+          adapter_options: [
+            app_id: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          ]
+      end
+
+  Then, you can call it like this:
+
+      iex> MyApp.ExchangeRates.latest_rates()
+      iex> MyApp.ExchangeRates.historic_rates(~D[2023-11-18])
+
+  ## Options
+
+  * `:otp` specifies the OTP application that holds related configuration.
+
+  * `:adapter` specifies the module to retrieve exchange rates. This can be any module that
+    implements the `Money.ExchangeRatesLite.Adapter` behaviour. The default is
+    `Money.ExchangeRatesLite.Adapter.OpenExchangeRates`.
+
+  * `:adapter_options` specifies the options of `:adapter`.
+
+  * `:http_client_adapter` specifies the module to cache exchange rates. This can be any module
+    that implements the `Money.ExchangeRatesLite.HttpClient.Adapter` behaviour. The default is
+    `Money.ExchangeRatesLite.HttpClient.Adapter.CldrHttp`.
+
+  * `:http_client_options` specifies the options of `:http_client_adapter`.
+
+  """
+
+  @schema_options [
+    otp_app: [
+      type: :atom,
+      required: true
+    ],
+    adapter: [
+      type: :atom,
+      default: Money.ExchangeRatesLite.Adapter.OpenExchangeRates
+    ],
+    adapter_options: [
+      type: :keyword_list,
+      default: []
+    ],
+    http_client_adapter: [
+      type: :atom,
+      default: Money.ExchangeRatesLite.HttpClient.Adapter.CldrHttp
+    ],
+    http_client_options: [
+      type: :keyword_list,
+      default: []
+    ]
+  ]
+
+  alias Money.ExchangeRatesLite.Config
+  alias Money.ExchangeRatesLite.Adapter
+  alias Money.ExchangeRatesLite.HttpClient.Config, as: HttpClientConfig
+
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts] do
+      alias Money.ExchangeRatesLite
+
+      @otp_app Keyword.fetch!(opts, :otp_app)
+      @module_opts opts
+
+      @spec latest_rates() :: Adapter.result()
+      def latest_rates() do
+        ExchangeRatesLite.latest_rates(config())
+      end
+
+      @spec historic_rates(Date.t()) :: Adapter.result()
+      def historic_rates(%Date{} = date) do
+        ExchangeRatesLite.historic_rates(config(), date)
+      end
+
+      @spec config() :: keyword()
+      def config() do
+        opts = ExchangeRatesLite.merge_opts(@otp_app, __MODULE__, @module_opts)
+        ExchangeRatesLite.build_config(opts)
+      end
+    end
+  end
+
+  @doc """
+  Gets the latest exchange rates.
+  """
+  @spec latest_rates(Config.t()) :: Adapter.result()
+  def latest_rates(%Config{} = config) do
+    config.adapter.get_latest_rates(config)
+  end
+
+  @doc """
+  Gets the historic exchange rates.
+  """
+  @spec historic_rates(Config.t(), Date.t()) :: Adapter.result()
+  def historic_rates(%Config{} = config, %Date{} = date) do
+    config.adapter.get_historic_rates(config, date)
+  end
+
+  @doc false
+  def merge_opts(otp_app, module, module_opts) do
+    Application.get_env(otp_app, module, [])
+    |> Keyword.merge(module_opts)
+  end
+
+  @doc false
+  def build_config(opts) do
+    validated_opts = NimbleOptions.validate!(opts, @schema_options)
+
+    adapter = Keyword.fetch!(validated_opts, :adapter)
+    adapter_options = Keyword.fetch!(validated_opts, :adapter_options)
+    http_client_adapter = Keyword.fetch!(validated_opts, :http_client_adapter)
+    http_client_options = Keyword.fetch!(validated_opts, :http_client_options)
+
+    http_client_config =
+      HttpClientConfig.new!(
+        adapter: http_client_adapter,
+        adapter_options: http_client_options
+      )
+
+    Config.new!(
+      adapter: adapter,
+      adapter_options: adapter_options,
+      http_client_config: http_client_config
+    )
+  end
+end

--- a/lib/money/exchange_rates_lite/adapter.ex
+++ b/lib/money/exchange_rates_lite/adapter.ex
@@ -1,0 +1,33 @@
+defmodule Money.ExchangeRatesLite.Adapter do
+  @moduledoc """
+  Specification of the exchange rates adapter.
+  """
+
+  alias Money.ExchangeRatesLite.Config
+
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts], unquote: true do
+      @schema_options opts[:schema_options] || []
+
+      @behaviour unquote(__MODULE__)
+
+      def schema_options(), do: @schema_options
+    end
+  end
+
+  @type exchange_rates :: %{Money.currency_code() => Decimal.t()}
+  @type reason :: any()
+  @type result :: {:ok, exchange_rates()} | {:ok, :not_modified} | {:error, reason()}
+
+  @doc """
+  Gets the the latest exchange rates.
+  """
+  @callback get_latest_rates(Config.t()) :: result()
+
+  @doc """
+  Gets the historic exchange rates.
+  """
+  @callback get_historic_rates(Config.t(), Date.t()) :: result()
+
+  @callback schema_options() :: NimbleOptions.schema()
+end

--- a/lib/money/exchange_rates_lite/adapter/open_exchange_rates.ex
+++ b/lib/money/exchange_rates_lite/adapter/open_exchange_rates.ex
@@ -1,0 +1,68 @@
+defmodule Money.ExchangeRatesLite.Adapter.OpenExchangeRates do
+  @moduledoc """
+  `Money.ExchangeRatesLite` adapter for [Open Exchange Rates](https://openexchangerates.org/).
+
+  ## Options
+
+    * `app_id` (required)
+    * `base_url` - the url to use as the API endpoint. Default value is
+      `"https://openexchangerates.org/api"`.
+
+  """
+
+  use Money.ExchangeRatesLite.Adapter,
+    schema_options: [
+      app_id: [
+        type: :string,
+        required: true
+      ],
+      base_url: [
+        type: :string,
+        default: "https://openexchangerates.org/api"
+      ]
+    ]
+
+  alias Money.ExchangeRatesLite.HttpClient
+  alias Money.ExchangeRatesLite.Config
+
+  @impl true
+  def get_latest_rates(%Config{} = config) do
+    url = "#{base_url(config)}/latest.json?app_id=#{app_id(config)}"
+
+    config.http_client_config
+    |> HttpClient.get(url)
+    |> handle_response()
+  end
+
+  @impl true
+  def get_historic_rates(%Config{} = config, date) do
+    date_string = Date.to_string(date)
+    url = "#{base_url(config)}/historical/#{date_string}.json?app_id=#{app_id(config)}"
+
+    config.http_client_config
+    |> HttpClient.get(url)
+    |> handle_response()
+  end
+
+  defp handle_response(response) do
+    case response do
+      {:ok, body} when is_binary(body) -> {:ok, decode_body(body)}
+      other -> other
+    end
+  end
+
+  defp decode_body(body) do
+    %{"base" => _base, "rates" => rates} = Money.json_library().decode!(body)
+
+    rates
+    |> Cldr.Map.atomize_keys()
+    |> Enum.map(fn
+      {k, v} when is_float(v) -> {k, Decimal.from_float(v)}
+      {k, v} when is_integer(v) -> {k, Decimal.new(v)}
+    end)
+    |> Enum.into(%{})
+  end
+
+  defp app_id(config), do: Keyword.fetch!(config.adapter_options, :app_id)
+  defp base_url(config), do: Keyword.fetch!(config.adapter_options, :base_url)
+end

--- a/lib/money/exchange_rates_lite/config.ex
+++ b/lib/money/exchange_rates_lite/config.ex
@@ -1,0 +1,41 @@
+defmodule Money.ExchangeRatesLite.Config do
+  alias Money.ExchangeRatesLite.HttpClient.Config, as: HttpClientConfig
+
+  @enforce_keys [:adapter, :adapter_options, :http_client_config]
+  defstruct @enforce_keys
+
+  @type options :: keyword()
+  @type t :: %__MODULE__{
+          adapter: module(),
+          adapter_options: keyword(),
+          http_client_config: HttpClientConfig.t()
+        }
+
+  @schema_main_options [
+    adapter: [
+      type: :atom,
+      default: Money.ExchangeRatesLite.Adapter.OpenExchangeRates
+    ],
+    http_client_config: [
+      type: {:struct, HttpClientConfig},
+      required: true
+    ]
+  ]
+
+  @spec new!(options()) :: t()
+  def new!(options) when is_list(options) do
+    {adapter_options, main_options} = Keyword.pop(options, :adapter_options, [])
+
+    main_options = NimbleOptions.validate!(main_options, @schema_main_options)
+    adapter = Keyword.fetch!(main_options, :adapter)
+
+    schema_adapter_options = adapter.schema_options()
+    adapter_options = NimbleOptions.validate!(adapter_options, schema_adapter_options)
+
+    as_struct([{:adapter_options, adapter_options} | main_options])
+  end
+
+  defp as_struct(options) do
+    struct(__MODULE__, options)
+  end
+end

--- a/lib/money/exchange_rates_lite/http_client.ex
+++ b/lib/money/exchange_rates_lite/http_client.ex
@@ -1,0 +1,91 @@
+defmodule Money.ExchangeRatesLite.HttpClient do
+  @moduledoc """
+  A multi-adapter，ETag-sensitive HTTP client.
+  """
+
+  alias __MODULE__.Config
+
+  @ets_cache_table __MODULE__.ETag
+
+  @type url :: binary()
+  @type header :: {binary(), binary()}
+  @type headers :: [header()]
+  @type body :: binary()
+  @type reason :: any()
+  @type result ::
+          {:ok, body()}
+          | {:ok, :not_modified}
+          | {:error, {module(), reason()}}
+
+  @doc false
+  @spec get(Config.t(), url(), headers()) :: result()
+  def get(%Config{} = config, url, headers \\ []) do
+    headers = build_headers(url, headers)
+
+    config
+    |> config.adapter.get(url, headers)
+    |> handle_response(url)
+  end
+
+  defp build_headers(url, headers) do
+    case get_etag(url) do
+      {etag, date} ->
+        [
+          {"If-None-Match", etag},
+          {"If-Modified-Since", date}
+          | headers
+        ]
+
+      _ ->
+        headers
+    end
+  end
+
+  defp handle_response({:ok, headers, body}, url) do
+    put_etag(url, headers)
+    {:ok, body}
+  end
+
+  defp handle_response({:not_modified, headers}, url) do
+    put_etag(url, headers)
+    {:ok, :not_modified}
+  end
+
+  defp handle_response({:error, reason}, _url) do
+    {:error, {__MODULE__, "#{inspect(reason)}"}}
+  end
+
+  defp ensure_cache_table() do
+    if :ets.info(@ets_cache_table) == :undefined do
+      :ets.new(@ets_cache_table, [:named_table, :public])
+    end
+
+    :ok
+  end
+
+  defp get_etag(url) do
+    ensure_cache_table()
+
+    case :ets.lookup(@ets_cache_table, url) do
+      [{^url, value}] -> value
+      [] -> nil
+    end
+  end
+
+  defp put_etag(url, headers) do
+    ensure_cache_table()
+
+    etag = :proplists.get_value("etag", headers)
+    date = :proplists.get_value("date", headers)
+
+    if valid_etag?(etag, date) do
+      :ets.insert(@ets_cache_table, {url, {etag, date}})
+    else
+      :ets.delete(@ets_cache_table, url)
+    end
+  end
+
+  defp valid_etag?(etag, date) do
+    etag != :undefined && date != :undefined
+  end
+end

--- a/lib/money/exchange_rates_lite/http_client/adapter.ex
+++ b/lib/money/exchange_rates_lite/http_client/adapter.ex
@@ -1,0 +1,30 @@
+defmodule Money.ExchangeRatesLite.HttpClient.Adapter do
+  @moduledoc """
+  Specification of the HTTP client adapter.
+  """
+
+  alias Money.ExchangeRatesLite.HttpClient.Config
+
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts], unquote: true do
+      @schema_options opts[:schema_options] || []
+
+      @behaviour unquote(__MODULE__)
+
+      def schema_options(), do: @schema_options
+    end
+  end
+
+  @type url :: binary()
+  @type header :: {binary(), binary()}
+  @type headers :: [header()]
+  @type body :: binary()
+  @type reason :: any()
+
+  @callback get(Config.t(), url(), headers()) ::
+              {:ok, headers(), body()}
+              | {:not_modified, headers()}
+              | {:error, reason()}
+
+  @callback schema_options() :: NimbleOptions.schema()
+end

--- a/lib/money/exchange_rates_lite/http_client/adapter/cldr_http.ex
+++ b/lib/money/exchange_rates_lite/http_client/adapter/cldr_http.ex
@@ -1,0 +1,45 @@
+defmodule Money.ExchangeRatesLite.HttpClient.Adapter.CldrHttp do
+  @moduledoc """
+  HTTP client adapter for `Cldr.Http`.
+  """
+
+  use Money.ExchangeRatesLite.HttpClient.Adapter,
+    schema_options: [
+      verify_peer: [
+        type: :boolean,
+        default: true
+      ]
+    ]
+
+  alias Money.ExchangeRatesLite.HttpClient.Config
+
+  @impl true
+  def get(%Config{} = config, url, headers) do
+    verify_peer = Keyword.fetch!(config.adapter_options, :verify_peer)
+    headers = format_request_headers(headers)
+
+    Cldr.Http.get_with_headers({url, headers}, verify_peer: verify_peer)
+    |> case do
+      {:ok, headers, body} ->
+        {:ok, format_response_headers(headers), format_response_body(body)}
+
+      {:not_modified, headers} ->
+        {:not_modified, format_response_headers(headers)}
+
+      other ->
+        other
+    end
+  end
+
+  defp format_request_headers(headers) do
+    Enum.map(headers, fn {key, value} -> {to_charlist(key), value} end)
+  end
+
+  defp format_response_headers(headers) do
+    Enum.map(headers, fn {key, value} -> {to_string(key), to_string(value)} end)
+  end
+
+  defp format_response_body(body) do
+    to_string(body)
+  end
+end

--- a/lib/money/exchange_rates_lite/http_client/config.ex
+++ b/lib/money/exchange_rates_lite/http_client/config.ex
@@ -1,0 +1,35 @@
+defmodule Money.ExchangeRatesLite.HttpClient.Config do
+  @enforce_keys [:adapter, :adapter_options]
+  defstruct @enforce_keys
+
+  @type options :: keyword()
+
+  @type t :: %__MODULE__{
+          adapter: module(),
+          adapter_options: keyword()
+        }
+
+  @schema_main_options [
+    adapter: [
+      type: :atom,
+      default: Money.ExchangeRatesLite.HttpClient.Adapter.CldrHttp
+    ]
+  ]
+
+  @spec new!(options()) :: t()
+  def new!(options) when is_list(options) do
+    {adapter_options, main_options} = Keyword.pop(options, :adapter_options, [])
+
+    main_options = NimbleOptions.validate!(main_options, @schema_main_options)
+    adapter = Keyword.fetch!(main_options, :adapter)
+
+    schema_adapter_options = adapter.schema_options()
+    adapter_options = NimbleOptions.validate!(adapter_options, schema_adapter_options)
+
+    as_struct([{:adapter_options, adapter_options} | main_options])
+  end
+
+  defp as_struct(options) do
+    struct(__MODULE__, options)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,7 @@ defmodule Money.Mixfile do
   defp deps do
     [
       {:ex_cldr_numbers, "~> 2.31"},
-
+      {:nimble_options, "~> 1.0"},
       {:nimble_parsec, "~> 0.5 or ~> 1.0"},
       {:decimal, "~> 1.6 or ~> 2.0"},
       {:poison, "~> 3.0 or ~> 4.0 or ~> 5.0", optional: true},
@@ -97,7 +97,6 @@ defmodule Money.Mixfile do
       {:benchee, "~> 1.0", optional: true, only: :dev},
       {:exprof, "~> 0.2", only: :dev, runtime: false},
       {:ex_doc, "0.30.5", only: [:dev, :release]},
-
       {:gringotts, "~> 1.1", optional: true}
     ]
     |> Enum.reject(&is_nil/1)

--- a/mix.lock
+++ b/mix.lock
@@ -29,6 +29,7 @@
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.2", "ad87296a092a46e03b7e9b0be7631ddcf64c790fa68a9ef5323b6cbb36affc72", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "f3f5a1ca93ce6e092d92b6d9c049bcda58a3b617a8d888f8e7231c85630e8108"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
+  "nimble_options": {:hex, :nimble_options, "1.0.2", "92098a74df0072ff37d0c12ace58574d26880e522c22801437151a159392270e", [:mix], [], "hexpm", "fd12a8db2021036ce12a309f26f564ec367373265b53e25403f0ee697380f1b8"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
   "parse_trans": {:hex, :parse_trans, "3.4.1", "6e6aa8167cb44cc8f39441d05193be6e6f4e7c2946cb2759f015f8c56b76e5ff", [:rebar3], [], "hexpm", "620a406ce75dada827b82e453c19cf06776be266f5a67cff34e1ef2cbb60e49a"},
   "phoenix_html": {:hex, :phoenix_html, "3.3.3", "380b8fb45912b5638d2f1d925a3771b4516b9a78587249cabe394e0a5d579dc9", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: true]}], "hexpm", "923ebe6fec6e2e3b3e569dfbdc6560de932cd54b000ada0208b5f45024bdd76c"},

--- a/test/money/exchange_rates_lite/http_client/adapter/cldr_http_test.exs
+++ b/test/money/exchange_rates_lite/http_client/adapter/cldr_http_test.exs
@@ -1,0 +1,26 @@
+defmodule Money.ExchangeRatesLite.HttpClient.Adapter.CldrHttpTest do
+  use ExUnit.Case
+
+  use ExUnit.Case, async: true
+
+  alias Money.ExchangeRatesLite.HttpClient.Config
+  alias Money.ExchangeRatesLite.HttpClient.Adapter.CldrHttp
+
+  setup do
+    config = Config.new!([])
+    [config: config]
+  end
+
+  describe "get/3" do
+    test "requests an url", %{config: config} do
+      assert {:ok, _headers, _body} = CldrHttp.get(config, "https://httpbin.org/status/200", [])
+    end
+
+    test "handles the headers", %{config: config} do
+      assert {:ok, _headers, body} =
+               CldrHttp.get(config, "https://httpbin.org/headers", [{"x-custom", ""}])
+
+      assert body =~ ~r/x-custom/i
+    end
+  end
+end

--- a/test/money/exchange_rates_lite/http_client/config_test.exs
+++ b/test/money/exchange_rates_lite/http_client/config_test.exs
@@ -1,0 +1,37 @@
+defmodule Money.ExchangeRatesLite.HttpClient.ConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Money.ExchangeRatesLite.HttpClient.Config
+
+  describe "new!/1" do
+    test "creates a %Config{}" do
+      assert %Config{} = Config.new!([])
+    end
+
+    test "handles default values of options" do
+      assert %Config{
+               adapter: Money.ExchangeRatesLite.HttpClient.Adapter.CldrHttp,
+               adapter_options: [verify_peer: true]
+             } = Config.new!([])
+    end
+
+    test "raises errors when giving bad options" do
+      assert_raise NimbleOptions.ValidationError,
+                   "unknown options [:unknown], valid options are: [:adapter]",
+                   fn ->
+                     Config.new!(unknown: true)
+                   end
+    end
+
+    test "raises errors when giving bad adapter options" do
+      assert_raise NimbleOptions.ValidationError,
+                   "unknown options [:unknown], valid options are: [:verify_peer]",
+                   fn ->
+                     Config.new!(
+                       adapter: Money.ExchangeRatesLite.HttpClient.Adapter.CldrHttp,
+                       adapter_options: [unknown: true]
+                     )
+                   end
+    end
+  end
+end

--- a/test/money/exchange_rates_lite/http_client_test.exs
+++ b/test/money/exchange_rates_lite/http_client_test.exs
@@ -1,0 +1,27 @@
+defmodule Money.ExchangeRatesLite.HttpClientTest do
+  use ExUnit.Case
+
+  alias Money.ExchangeRatesLite.HttpClient
+  alias Money.ExchangeRatesLite.HttpClient.Config
+
+  setup do
+    config = Config.new!([])
+
+    [config: config]
+  end
+
+  test "ETS table for caching ETag is created", %{config: config} do
+    url = "https://httpbin.org/status/200"
+
+    assert {:ok, _body} = HttpClient.get(config, url)
+    assert :ets.info(Money.ExchangeRatesLite.HttpClient.ETag) != :undefined
+  end
+
+  test "get/3 is ETag-sensitive", %{config: config} do
+    etag = :rand.uniform(1_000_000)
+    url = "https://httpbin.org/etag/#{etag}"
+
+    assert {:ok, _body} = HttpClient.get(config, url)
+    assert {:ok, :not_modified} = HttpClient.get(config, url)
+  end
+end


### PR DESCRIPTION
> I'm still working on this. If you like it, let me know ;)

This PR provides a lightweight version of `Money.ExchangeRates`. The main ideas are:

> + Only provides basic functions.
> + Making fewer assumptions in code organization.

Different from `Money.ExchangeRates`. It makes no assumptions over:

- supervision tree
- caching mechanism
- the way to retrieve exchange rates internally.

It just provides the functions to retrieve exchange rates, which will give developers all the freedom to build their own supervision tree, caching mechanism, etc.

With this PR, it's possible to do several things easily:
+ creating different modules for different exchange rates services.
+ using your own preferred cache mechanism
+ wrapping your own GenServer or create a pool for GenServers.

The only tradeoff is you have to write more code.

## an example: create different modules for different exchange rates services

```
defmodule MyApp.ExchangeRatesFromOpenExchangeRates do
  use Money.ExchangeRatesLite, otp_app: :my_app
    adapter: Money.ExchangeRatesLite.Adapter.OpenExchangeRates,
    adapter_options: [
      app_id: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
    ]
end
```

```
defmodule MyApp.ExchangeRatesFromExchangeRatesIO do
  use Money.ExchangeRatesLite, otp_app: :my_app,
    adapter: Money.ExchangeRatesLite.Adapter.ExchangeRatesIO
    adapter_options: [
      # ...
    ]
end
```
