### PR TITLE
Support digital token for currency conversion

### DIFF
--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -428,6 +428,12 @@ defmodule MoneyTest do
     assert Money.to_currency(Money.new(:USD, 100), "USD", rates) == {:ok, Money.new(:USD, 100)}
   end
 
+  test "money conversion with digital_token" do
+    rates = %{:USD => Decimal.new(50_000), "4H95J0R2X" => Decimal.new(1)}
+    assert Money.to_currency(Money.new(:USD, 50_000), "4H95J0R2X", rates) == {:ok, Money.new("4H95J0R2X", "1.00000")}
+    assert Money.to_currency(Money.new("4H95J0R2X", 1), :USD, rates) == {:ok, Money.new(:USD, 50_000)}
+  end
+
   test "money to_string" do
     assert Money.to_string(Money.new(:USD, 100)) == {:ok, "$100.00"}
   end


### PR DESCRIPTION
If you use digital token for exchange rates it'll go into a infinite loop because a digital token is always returned as a binary. This PR resolves that by validating if it is either an atom or a digital token.