### PR TITLE
Surface retriever startup error

### DIFF
--- a/lib/money/exchange_rates/exchange_rates_supervisor.ex
+++ b/lib/money/exchange_rates/exchange_rates_supervisor.ex
@@ -38,7 +38,7 @@ defmodule Money.ExchangeRates.Supervisor do
     options = Keyword.merge(default_options(), options)
     if options[:restart], do: stop()
     supervisor = start_link()
-    if options[:start_retriever], do: ExchangeRates.Retriever.start()
+    if options[:start_retriever], do: start_retriever!()
     supervisor
   end
 
@@ -188,5 +188,12 @@ defmodule Money.ExchangeRates.Supervisor do
 
   defp retriever_spec(config) do
     %{id: @child_name, start: {@child_name, :start_link, [@child_name, config]}}
+  end
+
+  defp start_retriever! do
+    case ExchangeRates.Retriever.start() do
+      {:ok, _pid} -> :ok
+      {:error, reason} -> raise "Unhandled error starting retriever; #{inspect reason}"
+    end
   end
 end


### PR DESCRIPTION
If you don't set the `:default_cldr_backend` for `:ex_money` (I had set for `:ex_cldr`), the retriever just silently fails start up, and subsequent exchange rates requests fails. Took me a sec to find out it was because the retriever just silently fails.

This change will surfaces any startup error by naively raising the reason, but I think there may be a better way to handle it or format the error. Not really a fan of this solution. I haven't added a test case for it as I couldn't find any tests for the exchange rates supervisor), and again, there's probably a better way to handle the upstart error inside the supervision tree.

The simplest way to test it is to change the test config to:

```elixir
config :ex_money,
  auto_start_exchange_rates_service: true,
  exchange_rates_retrieve_every: :timer.minutes(1),
  api_module: Money.ExchangeRates.OpenExchangesRates,
  # exchange_rates_retrieve_every: :never,
  # open_exchange_rates_app_id: {:system, "OPEN_EXCHANGE_RATES_APP_ID"},
  # api_module: Money.ExchangeRates.Api.Test,
  log_failure: nil,
  log_info: nil
  # default_cldr_backend: Test.Cldr
```

The other thing is to figure out why Money wouldn't fall back to the `:ex_cldr` `:default_cldr_backend` config for the supervisor.