### PR TITLE
fix(non-latin): properly handle non-latin locale scripts when initializing money.

### DIFF
--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -129,18 +129,22 @@ defmodule MoneyTest do
 
   test "that creating a money with a NaN is invalid" do
     assert Money.new(:USD, "NaN") ==
-             {:error, {Money.InvalidAmountError, "Invalid money amount. Found Decimal.new(\"NaN\")."}}
+             {:error,
+              {Money.InvalidAmountError, "Invalid money amount. Found Decimal.new(\"NaN\")."}}
 
     assert Money.new(:USD, "-NaN") ==
-             {:error, {Money.InvalidAmountError, "Invalid money amount. Found Decimal.new(\"-NaN\")."}}
+             {:error,
+              {Money.InvalidAmountError, "Invalid money amount. Found Decimal.new(\"-NaN\")."}}
   end
 
   test "that creating a money with a Inf is invalid" do
     assert Money.new(:USD, "Inf") ==
-             {:error, {Money.InvalidAmountError, "Invalid money amount. Found Decimal.new(\"Infinity\")."}}
+             {:error,
+              {Money.InvalidAmountError, "Invalid money amount. Found Decimal.new(\"Infinity\")."}}
 
     assert Money.new(:USD, "-Inf") ==
-             {:error, {Money.InvalidAmountError, "Invalid money amount. Found Decimal.new(\"-Infinity\")."}}
+             {:error,
+              {Money.InvalidAmountError, "Invalid money amount. Found Decimal.new(\"-Infinity\")."}}
   end
 
   test "that creating a money with a string amount that is invalid returns and error" do
@@ -430,8 +434,12 @@ defmodule MoneyTest do
 
   test "money conversion with digital_token" do
     rates = %{:USD => Decimal.new(50_000), "4H95J0R2X" => Decimal.new(1)}
-    assert Money.to_currency(Money.new(:USD, 50_000), "4H95J0R2X", rates) == {:ok, Money.new("4H95J0R2X", "1.00000")}
-    assert Money.to_currency(Money.new("4H95J0R2X", 1), :USD, rates) == {:ok, Money.new(:USD, 50_000)}
+
+    assert Money.to_currency(Money.new(:USD, 50_000), "4H95J0R2X", rates) ==
+             {:ok, Money.new("4H95J0R2X", "1.00000")}
+
+    assert Money.to_currency(Money.new("4H95J0R2X", 1), :USD, rates) ==
+             {:ok, Money.new(:USD, 50_000)}
   end
 
   test "money to_string" do
@@ -555,6 +563,15 @@ defmodule MoneyTest do
 
     Application.put_env(:ex_money, :default_cldr_backend, money_backend)
     Application.put_env(:ex_cldr, :default_backend, cldr_backend)
+  end
+
+  test "that non latn cldr are properly represented" do
+    Money.default_backend().put_locale("ar-EG")
+
+    assert Money.new(:EGP, "100")
+           |> Money.to_string() == {:ok, "‏١٠٠٫٠٠ ج.م.‏"}
+
+    Money.default_backend().put_locale("en")
   end
 
   test "that format options propogate through operations" do

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -568,8 +568,8 @@ defmodule MoneyTest do
   test "that non latn cldr are properly represented" do
     Money.default_backend().put_locale("ar-EG")
 
-    assert Money.new(:EGP, "100")
-           |> Money.to_string() == {:ok, "‏١٠٠٫٠٠ ج.م.‏"}
+    assert Money.new(:EGP, "10000.00")
+           |> Money.to_string() == {:ok, "‏١٠٬٠٠٠٫٠٠ ج.م.‏"}
 
     Money.default_backend().put_locale("en")
   end

--- a/test/support/test_cldr.ex
+++ b/test/support/test_cldr.ex
@@ -4,7 +4,19 @@ require Money
 defmodule Test.Cldr do
   use Cldr,
     default_locale: "en",
-    locales: ["en", "de", "da", "nl", "de-CH", "fr", "zh-Hant-HK", "zh-Hans", "ja", "es-CO"],
+    locales: [
+      "en",
+      "de",
+      "da",
+      "nl",
+      "de-CH",
+      "fr",
+      "zh-Hant-HK",
+      "zh-Hans",
+      "ja",
+      "es-CO",
+      "ar-EG"
+    ],
     providers: [Cldr.Number, Money],
     suppress_warnings: true
 end


### PR DESCRIPTION
Money.new when attempting maybe_decimal always assumes a latn script locale. ( ie: latn is hardcoded) which fails for any other locale script.