### PR TITLE
Fix exclude_protocol_implementation check for Jason.Encoder

### DIFF
--- a/lib/money/protocol/jason.ex
+++ b/lib/money/protocol/jason.ex
@@ -1,5 +1,5 @@
 if Cldr.Config.ensure_compiled?(Jason) &&
-    !Money.exclude_protocol_implementation(Json.Encoder) do
+     !Money.exclude_protocol_implementation(Jason.Encoder) do
   defimpl Jason.Encoder, for: Money do
     def encode(struct, opts) do
       struct


### PR DESCRIPTION
This looks like a typo. 