### PR TITLE
Check exclude_protocol_implementation for String.Chars defimpl

### DIFF
--- a/lib/money/protocol/string_chars.ex
+++ b/lib/money/protocol/string_chars.ex
@@ -1,5 +1,7 @@
-defimpl String.Chars, for: Money do
-  def to_string(v) do
-    Money.to_string!(v)
+if !Money.exclude_protocol_implementation(String.Chars) do
+  defimpl String.Chars, for: Money do
+    def to_string(v) do
+      Money.to_string!(v)
+    end
   end
 end


### PR DESCRIPTION
This change would be nice to allow us to use our existing implementation for number formatting while we wait for the new Cldr version to arrive.  