### PR TITLE
Update docs

### DIFF
--- a/lib/money/exchange_rates.ex
+++ b/lib/money/exchange_rates.ex
@@ -10,7 +10,7 @@ defmodule Money.ExchangeRates do
   The default configuration is:
 
       config :ex_money,
-        exchange_rate_service: false,
+        auto_start_exchange_rate_service: false,
         exchange_rates_retrieve_every: 300_000,
         api_module: Money.ExchangeRates.OpenExchangeRates,
         callback_module: Money.ExchangeRates.Callback,
@@ -21,7 +21,7 @@ defmodule Money.ExchangeRates do
 
   These keys are are defined as follows:
 
-  * `:exchange_rate_service` is a boolean that determines whether to
+  * `:auto_start_exchange_rate_service` is a boolean that determines whether to
     automatically start the exchange rate retrieval service.
     The default it false.
 
@@ -71,7 +71,7 @@ defmodule Money.ExchangeRates do
   An example configuration might be:
 
       config :ex_money,
-        exchange_rate_service: {:system, "RATE_SERVICE"},
+        auto_start_exchange_rate_service: {:system, "RATE_SERVICE"},
         exchange_rates_retrieve_every: {:system, "RETRIEVE_EVERY"},
 
   ## Open Exchange Rates


### PR DESCRIPTION
Replaces `exchange_rate_service` with `auto_start_exchange_rate_service` in `Money.ExchangeRates`.

I will follow up on a problem I encounter when `exchange_rates_retrieve_every` is set, it seems that the retriever does not start. However, I need to investigate this further.