### PR TITLE
Remove commented out debug statement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -92,8 +92,6 @@ defmodule Money.Mixfile do
   defp deps do
     [
       {:ex_cldr_numbers, "~> 2.33"},
-      # {:ex_cldr_numbers, path: "../cldr_numbers"},
-
       {:nimble_parsec, "~> 0.5 or ~> 1.0"},
       {:decimal, "~> 1.6 or ~> 2.0"},
       {:poison, "~> 3.0 or ~> 4.0 or ~> 5.0 or ~> 6.0", optional: true},


### PR DESCRIPTION
Remove a debug comment from `mix.exs`.

If this line was intentional, feel free to close!