### PR TITLE
Implement the JSON.Encoder protocol for Money

### DIFF
--- a/lib/money/protocol/json.ex
+++ b/lib/money/protocol/json.ex
@@ -1,0 +1,10 @@
+if Cldr.Config.ensure_compiled?(JSON) &&
+     !Money.exclude_protocol_implementation(JSON.Encoder) do
+  defimpl JSON.Encoder, for: Money do
+    def encode(struct, encoder) do
+      struct
+      |> Map.take([:currency, :amount])
+      |> encoder.(encoder)
+    end
+  end
+end


### PR DESCRIPTION
As mentioned initially in #176, the `JSON.Encoder` is not implemented for `Money` while `Jason.Encoder` is. I think it makes sense that Money directly implements it.