### PR TITLE
Align examples with new IO.inspect output format etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ The primary functions supporting subscriptions are:
 
     # Change plans in the middle of the current plan period
     # and credit the balance of the current plan to the new plan
-    iex> Money.Subscription.change_plan current_plan, new_plan, current_interval_started: ~D[2018-03-01], effective: ~D[2018-03-15]
+    iex> Money.Subscription.change_plan! current_plan, new_plan, current_interval_started: ~D[2018-03-01], effective: ~D[2018-03-15]
     %Money.Subscription.Change{
       first_billing_amount: Money.new(:USD, "4.51"),
       first_interval_starts: ~D[2018-03-15],


### PR DESCRIPTION
G'day @kipcole9!

I was merrily going through the examples in the readme in `iex` and noticed that `IO.inspect/2-3` has a new output format. I took the time to pay you back by aligning the outputs with the new format.

While going to town with the new output format I also noticed a few things you might appreciate:

- I noticed that you [removed `Money.default_currency_for_locale/1`](https://github.com/kipcole9/money/commit/d222318af35d867a12979527620ff21f53f67003) so I included a suggestion to remove the corresponding example in the readme.
- A few examples had the bang-output so I added exclamation marks in the invocations in the examples.
- `decimal` requires values such as `0.7345` to be passed as strings, didn't look into as of when though.
- The example for historic rates was missing the full module name so I added `Money.` in front of `ExchangeRates`.

One thing though, where I assume I'm just holding `ex_cldr` wrong, was the round trip formatting example where I couldn't get it to work with `Money.Cldr` as the provided backend.

```elixir
iex> {:ok, string} = Cldr.Number.to_string 1234, Money.Cldr, currency: :AUD
** (MatchError) no match of right hand side value: {:error, {Cldr.UnknownBackendError, "The backend Money.Cldr is not known or not a backend module."}}
(stdlib 6.2.2) erl_eval.erl:667: :erl_eval.expr/6
iex:1: (file)
```
I believe I have the backend [configured as per the Money docs](https://hexdocs.pm/ex_money/5.17.0/readme.html#configuring-locales-to-support-localised-formatting).

If I use `Money.default_backend/0`, which returns `MyApp.Cldr`, the example above works just fine. I don't know what makes most sense for a new library user or what's most appropriate.

---

These days I should mention that this contribution is 100% written by a human being and that I would never waste your time, or mine for that matter, with so-called "vibe coding". I favour serious computing 💼

Thank you so much for your contributions to the community Kip! ☺️