### PR TITLE
Fix deprecated map.field notation in Money.parse_decimal/4

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -3070,7 +3070,7 @@ defmodule Money do
   end
 
   defp parse_decimal(string, nil, backend, options) do
-    parse_decimal(string, backend.get_locale, backend, options)
+    parse_decimal(string, backend.get_locale(), backend, options)
   end
 
   defp parse_decimal(string, locale, nil, options) do


### PR DESCRIPTION
```
warning: using map.field notation (without parentheses) to invoke function Enaia.Cldr.get_locale() is deprecated, you must add parentheses instead: remote.function()
  (ex_money 5.24.1) lib/money.ex:3073: Money.parse_decimal/4
```