### PR TITLE
fix(exchange-rates): fix docs, specs and missing @impl annotations

### DIFF
--- a/lib/money/exchange_rates.ex
+++ b/lib/money/exchange_rates.ex
@@ -35,9 +35,10 @@ defmodule Money.ExchangeRates do
     `Money.ExchangeRates.OpenExchangeRates`.
 
   * `:callback_module` defines a module that follows the
-    Money.ExchangeRates.Callback behaviour whereby the function
-    `rates_retrieved/2` is invoked after every successful retrieval
-    of exchange rates. The default is `Money.ExchangeRates.Callback`.
+    `Money.ExchangeRates.Callback` behaviour whereby the functions
+    `latest_rates_retrieved/2` and `historic_rates_retrieved/2` are
+    invoked after every successful retrieval of exchange rates.
+    The default is `Money.ExchangeRates.Callback`.
 
   * `:preload_historic_rates` defines a date or a date range
     that will be requested when the exchange rate service starts up.

--- a/lib/money/exchange_rates.ex
+++ b/lib/money/exchange_rates.ex
@@ -4,7 +4,7 @@ defmodule Money.ExchangeRates do
   from an exchange rate service.
 
   Configuration for the exchange rate service is defined
-  in a `Money.ExchangeRates.Config` struct.  A default
+  in a `Money.ExchangeRates.Config` struct. A default
   configuration is returned by `Money.ExchangeRates.default_config/0`.
 
   The default configuration is:
@@ -19,11 +19,11 @@ defmodule Money.ExchangeRates do
         log_info: :info,
         log_success: nil
 
-  These keys are are defined as follows:
+  These keys are defined as follows:
 
   * `:auto_start_exchange_rate_service` is a boolean that determines whether to
     automatically start the exchange rate retrieval service.
-    The default it false.
+    The default is false.
 
   * `:exchange_rates_retrieve_every` defines how often the exchange
     rates are retrieved in milliseconds. The default is 5 minutes
@@ -39,17 +39,17 @@ defmodule Money.ExchangeRates do
     `rates_retrieved/2` is invoked after every successful retrieval
     of exchange rates. The default is `Money.ExchangeRates.Callback`.
 
-  * `:preload_historic_rates` defines a date or a date range,
+  * `:preload_historic_rates` defines a date or a date range
     that will be requested when the exchange rate service starts up.
     The date or date range should be specified as either a `Date.t`
     or a `Date.Range.t` or a tuple of `{Date.t, Date.t}` representing
     the `from` and `to` dates for the rates to be retrieved. The
     default is `nil` meaning no historic rates are preloaded.
 
-  * `:log_failure` defines the log level at which api retrieval
+  * `:log_failure` defines the log level at which API retrieval
     errors are logged. The default is `:warning`.
 
-  * `:log_success` defines the log level at which successful api
+  * `:log_success` defines the log level at which successful API
     retrieval notifications are logged. The default is `nil` which
     means no logging.
 
@@ -58,8 +58,8 @@ defmodule Money.ExchangeRates do
 
   * `:retriever_options` is available for exchange rate retriever
     module developers as a place to add retriever-specific configuration
-    information.  This information should be added in the `init/1`
-    callback in the retriever module.  See `Money.ExchangeRates.OpenExchangeRates.init/1`
+    information. This information should be added in the `init/1`
+    callback in the retriever module. See `Money.ExchangeRates.OpenExchangeRates.init/1`
     for an example.
 
   Keys can also be configured to retrieve values from environment
@@ -77,7 +77,7 @@ defmodule Money.ExchangeRates do
   ## Open Exchange Rates
 
   If you plan to use the provided Open Exchange Rates module
-  to retrieve exchange rates then you should also provide the additional
+  to retrieve exchange rates, then you should also provide the additional
   configuration key for `app_id`:
 
       config :ex_money,
@@ -90,15 +90,15 @@ defmodule Money.ExchangeRates do
 
   The default exchange rate retrieval module is provided in
   `Money.ExchangeRates.OpenExchangeRates` which can be used
-  as a example to implement your own retrieval module for
+  as an example to implement your own retrieval module for
   other services.
 
   ## Managing the configuration at runtime
 
   During exchange rate service startup, the function `init/1` is called
-  on the configuration exchange rate retrieval module.  This module is
+  on the configuration exchange rate retrieval module. This module is
   expected to return an updated configuration allowing a developer to
-  customise how the configuration is to be managed.  See the implementation
+  customise how the configuration is to be managed. See the implementation
   at `Money.ExchangeRates.OpenExchangeRates.init/1` for an example.
 
   """
@@ -110,7 +110,7 @@ defmodule Money.ExchangeRates do
   Invoked to return the latest exchange rates from the configured
   exchange rate retrieval service.
 
-  * `config` is an `%Money.ExchangeRataes.Config{}` struct
+  * `config` is an `%Money.ExchangeRates.Config{}` struct
 
   Returns `{:ok, map_of_rates}` or `{:error, reason}`
 
@@ -122,7 +122,9 @@ defmodule Money.ExchangeRates do
   Invoked to return the historic exchange rates from the configured
   exchange rate retrieval service.
 
-  * `config` is an `%Money.ExchangeRataes.Config{}` struct
+  * `date` is a `Date.t()` used to identify the date for which rates are requested
+
+  * `config` is an `%Money.ExchangeRates.Config{}` struct
 
   Returns `{:ok, map_of_historic_rates}` or `{:error, reason}`
 
@@ -132,7 +134,7 @@ defmodule Money.ExchangeRates do
 
   @doc """
   Decode the body returned from the API request and
-  return a map of rates.  THe map of rates must have
+  return a map of rates. The map of rates must have
   an upcased atom key representing an ISO 4217 currency
   code and the value must be a Decimal number.
   """
@@ -142,13 +144,13 @@ defmodule Money.ExchangeRates do
   Given the default configuration, returns an updated configuration at runtime
   during exchange rates service startup.
 
-  This callback is optional.  If the callback is not defined, the default
+  This callback is optional. If the callback is not defined, the default
   configuration returned by `Money.ExchangeRates.default_config/0` is used.
 
   * `config` is the configuration returned by `Money.ExchangeRates.default_config/0`
 
   The callback is expected to return a `%Money.ExchangeRates.Config.t()` struct
-  which may have been updated.  The configuration key `:retriever_options` is
+  which may have been updated. The configuration key `:retriever_options` is
   available for any service-specific configuration.
 
   """
@@ -224,17 +226,17 @@ defmodule Money.ExchangeRates do
   end
 
   @doc """
-  Return the latest exchange rates.
+  Returns the latest exchange rates.
 
   Returns:
 
-  * `{:ok, rates}` if exchange rates are successfully retrieved.  `rates` is a map of
+  * `{:ok, rates}` if exchange rates are successfully retrieved. `rates` is a map of
     exchange rates.
 
   * `{:error, reason}` if no exchange rates can be returned.
 
-  This function looks up the latest exchange rates in a an ETS table
-  called `:exchange_rates`.  The actual retrieval of rates is requested
+  This function looks up the latest exchange rates in an ETS table
+  called `:exchange_rates`. The actual retrieval of rates is requested
   through `Money.ExchangeRates.Retriever.latest_rates/0`.
 
   """
@@ -252,22 +254,22 @@ defmodule Money.ExchangeRates do
   end
 
   @doc """
-  Return historic exchange rates.
+  Returns historic exchange rates.
 
   * `date` is a date returned by `Date.new/3` or any struct with the
     elements `:year`, `:month` and `:day`.
 
   Returns:
 
-  * `{:ok, rates}` if exchange rates are successfully retrieved.  `rates` is a map of
+  * `{:ok, rates}` if exchange rates are successfully retrieved. `rates` is a map of
     exchange rates.
 
   * `{:error, reason}` if no exchange rates can be returned.
 
-  **Note;** all dates are expected to be in the Calendar.ISO calendar
+  **Note:** All dates are expected to be in the Calendar.ISO calendar.
 
-  This function looks up the historic exchange rates in a an ETS table
-  called `:exchange_rates`.  The actual retrieval of rates is requested
+  This function looks up the historic exchange rates in an ETS table
+  called `:exchange_rates`. The actual retrieval of rates is requested
   through `Money.ExchangeRates.Retriever.historic_rates/1`.
 
   """
@@ -286,7 +288,7 @@ defmodule Money.ExchangeRates do
 
   @doc """
   Returns `true` if the latest exchange rates are available
-  and false otherwise.
+  and `false` otherwise.
   """
   @spec latest_rates_available?() :: boolean
   def latest_rates_available? do
@@ -302,7 +304,7 @@ defmodule Money.ExchangeRates do
   end
 
   @doc """
-  Return the timestamp of the last successful retrieval of exchange rates or
+  Returns the timestamp of the last successful retrieval of exchange rates or
   `{:error, reason}` if no timestamp is known.
 
   ## Example

--- a/lib/money/exchange_rates/cache/exchange_rates_cache_dets.ex
+++ b/lib/money/exchange_rates/cache/exchange_rates_cache_dets.ex
@@ -14,11 +14,13 @@ defmodule Money.ExchangeRates.Cache.Dets do
   require Money.ExchangeRates.Cache.EtsDets
   Money.ExchangeRates.Cache.EtsDets.define_common_functions()
 
+  @impl true
   def init do
     {:ok, name} = :dets.open_file(@ets_table, file: @dets_path)
     name
   end
 
+  @impl true
   def terminate do
     :dets.close(@ets_table)
   end

--- a/lib/money/exchange_rates/cache/exchange_rates_cache_ets.ex
+++ b/lib/money/exchange_rates/cache/exchange_rates_cache_ets.ex
@@ -1,7 +1,7 @@
 defmodule Money.ExchangeRates.Cache.Ets do
   @moduledoc """
   Money.ExchangeRates.Cache implementation for
-  :ets and :dets
+  :ets
   """
 
   @behaviour Money.ExchangeRates.Cache

--- a/lib/money/exchange_rates/cache/exchange_rates_cache_ets.ex
+++ b/lib/money/exchange_rates/cache/exchange_rates_cache_ets.ex
@@ -12,6 +12,7 @@ defmodule Money.ExchangeRates.Cache.Ets do
   require Money.ExchangeRates.Cache.EtsDets
   Money.ExchangeRates.Cache.EtsDets.define_common_functions()
 
+  @impl true
   def init do
     if :ets.info(@ets_table) == :undefined do
       :ets.new(@ets_table, [
@@ -24,6 +25,7 @@ defmodule Money.ExchangeRates.Cache.Ets do
     end
   end
 
+  @impl true
   def terminate do
     :ok
   end

--- a/lib/money/exchange_rates/cache/exchange_rates_cache_etsdets.ex
+++ b/lib/money/exchange_rates/cache/exchange_rates_cache_etsdets.ex
@@ -1,4 +1,6 @@
 defmodule Money.ExchangeRates.Cache.EtsDets do
+  @moduledoc false
+
   defmacro define_common_functions do
     quote do
       def latest_rates do

--- a/lib/money/exchange_rates/cache/exchange_rates_cache_etsdets.ex
+++ b/lib/money/exchange_rates/cache/exchange_rates_cache_etsdets.ex
@@ -3,6 +3,7 @@ defmodule Money.ExchangeRates.Cache.EtsDets do
 
   defmacro define_common_functions do
     quote do
+      @impl Money.ExchangeRates.Cache
       def latest_rates do
         case get(:latest_rates) do
           nil ->
@@ -13,6 +14,7 @@ defmodule Money.ExchangeRates.Cache.EtsDets do
         end
       end
 
+      @impl Money.ExchangeRates.Cache
       def historic_rates(%Date{calendar: Calendar.ISO} = date) do
         case get(date) do
           nil ->
@@ -29,6 +31,7 @@ defmodule Money.ExchangeRates.Cache.EtsDets do
         historic_rates(date)
       end
 
+      @impl Money.ExchangeRates.Cache
       def last_updated do
         case get(:last_updated) do
           nil ->
@@ -40,11 +43,13 @@ defmodule Money.ExchangeRates.Cache.EtsDets do
         end
       end
 
+      @impl Money.ExchangeRates.Cache
       def store_latest_rates(rates, retrieved_at) do
         put(:latest_rates, rates)
         put(:last_updated, retrieved_at)
       end
 
+      @impl Money.ExchangeRates.Cache
       def store_historic_rates(rates, date) do
         put(date, rates)
       end

--- a/lib/money/exchange_rates/callback_module.ex
+++ b/lib/money/exchange_rates/callback_module.ex
@@ -8,14 +8,16 @@ defmodule Money.ExchangeRates.Callback do
   """
 
   @doc """
-  Invoked after the latest exchange rates are successfully retrieved from an external
-  data source.
+  Invoked after the latest exchange rates have been successfully retrieved.
+  Use this callback to perform any desired side effects such as persisting
+  rates to a database.
   """
   @callback latest_rates_retrieved(%{}, DateTime.t()) :: :ok
 
   @doc """
-  Invoked after historic exchange rates are successfully retrieved from an external
-  data source.
+  Invoked after historic exchange rates for a given date have been successfully
+  retrieved. Use this callback to perform any desired side effects such as
+  persisting rates to a database.
   """
   @callback historic_rates_retrieved(%{}, Date.t()) :: :ok
 

--- a/lib/money/exchange_rates/callback_module.ex
+++ b/lib/money/exchange_rates/callback_module.ex
@@ -4,17 +4,17 @@ defmodule Money.ExchangeRates.Callback do
 
   When exchange rates are successfully retrieved, the function
   `latest_rates_retrieved/2` or `historic_rates_retrieved/2` is
-  called to perform any desired serialization or proocessing.
+  called to perform any desired serialization or processing.
   """
 
   @doc """
-  Defines the behaviour to retrieve the latest exchange rates from an external
+  Invoked after the latest exchange rates are successfully retrieved from an external
   data source.
   """
   @callback latest_rates_retrieved(%{}, DateTime.t()) :: :ok
 
   @doc """
-  Defines the behaviour to retrieve historic exchange rates from an external
+  Invoked after historic exchange rates are successfully retrieved from an external
   data source.
   """
   @callback historic_rates_retrieved(%{}, Date.t()) :: :ok

--- a/lib/money/exchange_rates/exchange_rates_cache.ex
+++ b/lib/money/exchange_rates/exchange_rates_cache.ex
@@ -1,6 +1,6 @@
 defmodule Money.ExchangeRates.Cache do
   @moduledoc """
-  Defines a cache behaviour and default inplementation
+  Defines a cache behaviour and default implementation
   of a cache for exchange rates
   """
 
@@ -11,7 +11,7 @@ defmodule Money.ExchangeRates.Cache do
   @callback init() :: any()
 
   @doc """
-  Terminate the cache when the retriver process
+  Terminate the cache when the retriever process
   stops normally
   """
   @callback terminate() :: any()
@@ -23,7 +23,7 @@ defmodule Money.ExchangeRates.Cache do
   @callback latest_rates() :: {:ok, map()} | {:error, {Exception.t(), String.t()}}
 
   @doc """
-  Returns the exchange rates for a given
+  Retrieve the exchange rates for a given
   date.
   """
   @callback historic_rates(Date.t()) :: {:ok, map()} | {:error, {Exception.t(), String.t()}}

--- a/lib/money/exchange_rates/exchange_rates_cache.ex
+++ b/lib/money/exchange_rates/exchange_rates_cache.ex
@@ -1,7 +1,6 @@
 defmodule Money.ExchangeRates.Cache do
   @moduledoc """
-  Defines a cache behaviour and default implementation
-  of a cache for exchange rates
+  Defines the cache behaviour for exchange rates.
   """
 
   @doc """
@@ -44,14 +43,17 @@ defmodule Money.ExchangeRates.Cache do
   """
   @callback store_historic_rates(map(), Date.t()) :: :ok
 
+  @doc false
   def latest_rates do
     cache().latest_rates
   end
 
+  @doc false
   def historic_rates(date) do
     cache().historic_rates(date)
   end
 
+  @doc false
   def cache do
     Money.ExchangeRates.Retriever.config().cache_module
   end

--- a/lib/money/exchange_rates/exchange_rates_cache.ex
+++ b/lib/money/exchange_rates/exchange_rates_cache.ex
@@ -29,6 +29,11 @@ defmodule Money.ExchangeRates.Cache do
   @callback historic_rates(Date.t()) :: {:ok, map()} | {:error, {Exception.t(), String.t()}}
 
   @doc """
+  Return the timestamp when the exchange rates were last updated.
+  """
+  @callback last_updated() :: {:ok, DateTime.t()} | {:error, {Exception.t(), String.t()}}
+
+  @doc """
   Store the latest exchange rates in the cache.
   """
   @callback store_latest_rates(map(), DateTime.t()) :: :ok

--- a/lib/money/exchange_rates/exchange_rates_retriever.ex
+++ b/lib/money/exchange_rates/exchange_rates_retriever.ex
@@ -1,13 +1,13 @@
 defmodule Money.ExchangeRates.Retriever do
   @moduledoc """
   Implements a `GenServer` to retrieve exchange rates from
-  a configured retrieveal module on a periodic or on demand basis.
+  a configured retrieval module on a periodic or on demand basis.
 
   By default exchange rates are retrieved from [Open Exchange Rates](http://openexchangerates.org).
 
   The default period of execution is 5 minutes (300_000 milliseconds). The
   period of retrieval is configured in `config.exs` or the appropriate
-  environment configuration.  For example:
+  environment configuration. For example:
 
       config :ex_money,
         retrieve_every: 300_000
@@ -59,14 +59,14 @@ defmodule Money.ExchangeRates.Retriever do
   @doc """
   Forces retrieval of the latest exchange rates
 
-  Sends a message ot the exchange rate retrieval worker to request
+  Sends a message to the exchange rate retrieval worker to request
   current rates be retrieved and stored.
 
   Returns:
 
   * `{:ok, rates}` if exchange rates request is successfully sent.
 
-  * `{:error, reason}` if the request cannot be send.
+  * `{:error, reason}` if the request cannot be sent.
 
   This function does not return exchange rates, for that see
   `Money.ExchangeRates.latest_rates/0` or
@@ -93,9 +93,9 @@ defmodule Money.ExchangeRates.Retriever do
 
   * `{:ok, rates}` if exchange rates request is successfully sent.
 
-  * `{:error, reason}` if the request cannot be send.
+  * `{:error, reason}` if the request cannot be sent.
 
-  Sends a message ot the exchange rate retrieval worker to request
+  Sends a message to the exchange rate retrieval worker to request
   historic rates for a specified date or range be retrieved and
   stored.
 
@@ -135,7 +135,7 @@ defmodule Money.ExchangeRates.Retriever do
 
   * `{:ok, rates}` if exchange rates request is successfully sent.
 
-  * `{:error, reason}` if the request cannot be send.
+  * `{:error, reason}` if the request cannot be sent.
 
   Sends a message to the exchange rate retrieval process for each
   date in the range `from`..`to` to request historic rates be
@@ -162,7 +162,7 @@ defmodule Money.ExchangeRates.Retriever do
   end
 
   @doc """
-  Updated the configuration for the Exchange Rate
+  Updates the configuration for the Exchange Rate
   Service
 
   """
@@ -171,7 +171,7 @@ defmodule Money.ExchangeRates.Retriever do
   end
 
   @doc """
-  Return the current configuration of the Exchange Rates
+  Returns the current configuration of the Exchange Rates
   Retrieval service
 
   """
@@ -184,7 +184,7 @@ defmodule Money.ExchangeRates.Retriever do
   service.
 
   This function is primarily intended for use by
-  an exchange rates api module.
+  an exchange rates API module.
   """
   def retrieve_rates(url, config) when is_binary(url) do
     url

--- a/lib/money/exchange_rates/exchange_rates_supervisor.ex
+++ b/lib/money/exchange_rates/exchange_rates_supervisor.ex
@@ -110,7 +110,7 @@ defmodule Money.ExchangeRates.Supervisor do
   retriever. The returned value is one of:
 
   * `:running` if the service is running. In this
-    state the valid action is `Money.ExchangeRates.Service.stop/0`.
+    state the valid action is `Money.ExchangeRates.Retriever.stop/0`.
 
   * `:stopped` if it is stopped. In this state
     the valid actions are `Money.ExchangeRates.Supervisor.restart_retriever/0`

--- a/lib/money/exchange_rates/exchange_rates_supervisor.ex
+++ b/lib/money/exchange_rates/exchange_rates_supervisor.ex
@@ -10,6 +10,11 @@ defmodule Money.ExchangeRates.Supervisor do
 
   @child_name ExchangeRates.Retriever
 
+  @doc false
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok, name: ExchangeRates.Supervisor)
+  end
+
   @doc """
   Starts the Exchange Rates supervisor and
   optionally starts the exchange rates
@@ -30,10 +35,6 @@ defmodule Money.ExchangeRates.Supervisor do
     defined by the configuration key
     `:auto_start_exchange_rate_service`
   """
-  def start_link do
-    Supervisor.start_link(__MODULE__, :ok, name: ExchangeRates.Supervisor)
-  end
-
   def start_link(options) do
     options = Keyword.merge(default_options(), options)
     if options[:restart], do: stop()

--- a/lib/money/exchange_rates/exchange_rates_supervisor.ex
+++ b/lib/money/exchange_rates/exchange_rates_supervisor.ex
@@ -18,15 +18,15 @@ defmodule Money.ExchangeRates.Supervisor do
   ## Options
 
   * `:restart` is a boolean value indicating
-    if the supervisor is to be restarted.  This is
+    if the supervisor is to be restarted. This is
     typically used to move the supervisor from its
     default position under the `ex_money` supervision
-    tree to a different supervision tree.  The default
+    tree to a different supervision tree. The default
     is `false`
 
   * `:start_retriever` is a boolean indicating
     if the exchange rates retriever is to be started
-    when the supervisor is started.  The default is
+    when the supervisor is started. The default is
     defined by the configuration key
     `:auto_start_exchange_rate_service`
   """
@@ -53,7 +53,7 @@ defmodule Money.ExchangeRates.Supervisor do
   Stop the Money.ExchangeRates.Supervisor.
 
   Unless `ex_money` is configured in `mix.exs` as
-  `rumtime: false`, the Money.ExchangeRates.Supervisor
+  `runtime: false`, the Money.ExchangeRates.Supervisor
   is always started when `ex_money` starts even if the
   config key `:auto_start_exchange_rates_service` is
   set to `false`.
@@ -61,17 +61,17 @@ defmodule Money.ExchangeRates.Supervisor do
 
   In some instances an application may require the
   `Money.ExchangeRates.Supervisor` to be started under
-  a different supervision tree.  In this case it is
+  a different supervision tree. In this case it is
   required to call this function first before a new
   configuration is started.
 
   One use case is when the Exchange Rates service is
   configured with either an API module, a Callback module
-  or a Cache module which uses Ecto and therefore its
+  or a Cache module which uses Ecto and therefore it's
   a requirement that Ecto is started first.
 
   See the README section on "Using Ecto or other applications
-  from within the callback module" for an eanple of how
+  from within the callback module" for an example of how
   to configure the supervisor in this case.
   """
   def stop(supervisor \\ default_supervisor()) do
@@ -97,7 +97,7 @@ defmodule Money.ExchangeRates.Supervisor do
   end
 
   @doc """
-  Returns a boolean indicating of the
+  Returns a boolean indicating whether the
   retriever process is configured and
   running
   """
@@ -107,7 +107,7 @@ defmodule Money.ExchangeRates.Supervisor do
 
   @doc """
   Returns the status of the exchange rates
-  retriever.  The returned value is one of:
+  retriever. The returned value is one of:
 
   * `:running` if the service is running. In this
     state the valid action is `Money.ExchangeRates.Service.stop/0`.
@@ -117,7 +117,7 @@ defmodule Money.ExchangeRates.Supervisor do
     or `Money.ExchangeRates.Supervisor.delete_retriever/0`.
 
   * `:not_started` if it is not configured
-    in the supervisor and is not running.  In
+    in the supervisor and is not running. In
     this state the only valid action is
     `Money.ExchangeRates.Supervisor.start_retriever/1`.
 
@@ -143,7 +143,7 @@ defmodule Money.ExchangeRates.Supervisor do
 
   * `config` is a `t:Money.ExchangeRates.Config.t/0`
     struct returned by `Money.ExchangeRates.config/0`
-    and adjusted as required.  The default is
+    and adjusted as required. The default is
     `Money.ExchangeRates.config/0`.
 
   """
@@ -168,7 +168,7 @@ defmodule Money.ExchangeRates.Supervisor do
   end
 
   @doc """
-  Deleted the retriever child specification from
+  Deletes the retriever child specification from
   the exchange rates supervisor.
 
   This is primarily of use if you want to change

--- a/lib/money/exchange_rates/exchange_rates_supervisor.ex
+++ b/lib/money/exchange_rates/exchange_rates_supervisor.ex
@@ -93,6 +93,7 @@ defmodule Money.ExchangeRates.Supervisor do
   end
 
   @doc false
+  @impl true
   def init(:ok) do
     Supervisor.init([], strategy: :one_for_one)
   end

--- a/lib/money/exchange_rates/open_exchange_rates.ex
+++ b/lib/money/exchange_rates/open_exchange_rates.ex
@@ -49,6 +49,15 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
     Map.put(default_config, :retriever_options, %{url: url, app_id: app_id})
   end
 
+  @doc """
+  Decodes the JSON body returned by the Open Exchange Rates API.
+
+  * `body` is the raw response body as a binary or charlist.
+
+  Returns:
+
+  * A map of currency code atoms to `Decimal` exchange rate values.
+  """
   def decode_rates(body) when is_list(body) do
     body
     |> List.to_string()

--- a/lib/money/exchange_rates/open_exchange_rates.ex
+++ b/lib/money/exchange_rates/open_exchange_rates.ex
@@ -6,7 +6,7 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
   ## Required configuration:
 
   The configuration key `:open_exchange_rates_app_id` should be
-  set to your `app_id`.  for example:
+  set to your `app_id`. For example:
 
       config :ex_money,
         open_exchange_rates_app_id: "your_app_id"
@@ -33,7 +33,7 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
 
   @doc """
   Update the retriever configuration to include the requirements
-  for Open Exchange Rates.  This function is invoked when the
+  for Open Exchange Rates. This function is invoked when the
   exchange rate service starts up, just after the ets table
   :exchange_rates is created.
 
@@ -71,8 +71,8 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
   Retrieves the latest exchange rates from Open Exchange Rates site.
 
   * `config` is the retrieval configuration. When invoked from the
-  exchange rates services this will be the config returned from
-  `Money.ExchangeRates.config/0`
+    exchange rates service this will be the config returned from
+    `Money.ExchangeRates.config/0`
 
   Returns:
 
@@ -108,7 +108,7 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
     elements `:year`, `:month` and `:day`.
 
   * `config` is the retrieval configuration. When invoked from the
-    exchange rates services this will be the config returned from
+    exchange rates service this will be the config returned from
     `Money.ExchangeRates.config/0`
 
   Returns:
@@ -149,6 +149,6 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
   end
 
   defp app_id_not_configured do
-    "Open Exchange Rates app_id is not configured.  Rates are not retrieved."
+    "Open Exchange Rates app_id is not configured. Rates are not retrieved."
   end
 end

--- a/lib/money/exchange_rates/open_exchange_rates.ex
+++ b/lib/money/exchange_rates/open_exchange_rates.ex
@@ -43,6 +43,7 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
   additional configuration specific to this exchange
   rates retrieval module.
   """
+  @impl true
   def init(default_config) do
     url = Money.get_env(:open_exchange_rates_url, @open_exchange_rate_url)
     app_id = Money.get_env(:open_exchange_rates_app_id, nil)
@@ -58,6 +59,7 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
 
   * A map of currency code atoms to `Decimal` exchange rate values.
   """
+  @impl true
   def decode_rates(body) when is_list(body) do
     body
     |> List.to_string()
@@ -94,7 +96,7 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
   required.
 
   """
-  @spec get_latest_rates(Money.ExchangeRates.Config.t()) :: {:ok, map()} | {:error, String.t()}
+  @impl true
   def get_latest_rates(config) do
     url = config.retriever_options.url
     app_id = config.retriever_options.app_id
@@ -130,6 +132,7 @@ defmodule Money.ExchangeRates.OpenExchangeRates do
   service although it can be called outside that context as
   required.
   """
+  @impl true
   def get_historic_rates(date, config) do
     url = config.retriever_options.url
     app_id = config.retriever_options.app_id

--- a/test/money_exchange_rates_test.exs
+++ b/test/money_exchange_rates_test.exs
@@ -67,7 +67,7 @@ defmodule Money.ExchangeRates.Test do
     config = Map.put(config, :log_levels, %{failure: nil, info: nil, success: nil})
 
     assert Money.ExchangeRates.OpenExchangeRates.get_latest_rates(config) ==
-             {:error, "Open Exchange Rates app_id is not configured.  Rates are not retrieved."}
+             {:error, "Open Exchange Rates app_id is not configured. Rates are not retrieved."}
   end
 
   if System.get_env("OPEN_EXCHANGE_RATES_APP_ID") do


### PR DESCRIPTION
While working on refactoring the exchange rates module, I noticed some documentation issues and decided to fix them in a dedicated PR.

The changes cover typos, double spaces, incorrect function and module references, wrong callback descriptions, and missing `@impl` annotations across the `exchange_rates` subsystem.