### PR TITLE
refactor(exchange-rates): use different caches per retriever

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ An optional callback module can also be defined.  This module defines a `rates_r
   * `Money.ExchangeRates.Cache.Ets` which is also the default.
   * `Money.ExchangeRates.Cache.Dets`
 
+  A custom `Money.ExchangeRates.Cache` implementation written against an older version of `ex_money` still works, but raises a compiler warning - see the "Migrating from the deprecated singleton callbacks" section in the `Money.ExchangeRates.Cache` docs for how to update it.
+
 * `:retriever_options` is available for exchange rate retriever module developers as a place to add retriever-specific configuration information.  This information should be added in the `init/1` callback in the retriever module.  See `Money.ExchangeRates.OpenExchangeRates.init/1` for an example.
 
 * `:preload_historic_rates` defines a date or a date range that will be requested when the exchange rate service starts up. The date or date range should be specified as either a `Date.t` or a `Date.Range.t` or a tuple of `{Date.t, Date.t}` representing the `from` and `to` dates for the rates to be retrieved. The default is `nil` meaning no historic rates are preloaded. See [Preloading historic rates](#preloading-historic-rates) for more information.

--- a/lib/money/exchange_rates.ex
+++ b/lib/money/exchange_rates.ex
@@ -112,7 +112,7 @@ defmodule Money.ExchangeRates do
 
   """
   @callback get_latest_rates(config :: Money.ExchangeRates.Config.t()) ::
-              {:ok, map() | :not_modified} | {:error, binary}
+              {:ok, t() | :not_modified} | {:error, binary}
 
   @doc """
   Invoked to return the historic exchange rates from the configured
@@ -127,7 +127,7 @@ defmodule Money.ExchangeRates do
 
   """
   @callback get_historic_rates(Date.t(), config :: Money.ExchangeRates.Config.t()) ::
-              {:ok, map() | :not_modified} | {:error, binary}
+              {:ok, t() | :not_modified} | {:error, binary}
 
   @doc """
   Given the default configuration, returns an updated configuration at runtime
@@ -244,7 +244,7 @@ defmodule Money.ExchangeRates do
   through `Money.ExchangeRates.Retriever.latest_rates/0`.
 
   """
-  @spec latest_rates() :: {:ok, map()} | {:error, {Exception.t(), binary}}
+  @spec latest_rates() :: {:ok, t()} | {:error, {Exception.t(), binary}}
   def latest_rates do
     Retriever.latest_rates()
   end
@@ -268,9 +268,9 @@ defmodule Money.ExchangeRates do
   through `Money.ExchangeRates.Retriever.historic_rates/1`.
 
   """
-  @spec historic_rates(Calendar.date()) :: {:ok, map()} | {:error, {Exception.t(), binary}}
+  @spec historic_rates(Calendar.date()) :: {:ok, t()} | {:error, {Exception.t(), binary}}
   @spec historic_rates(Date.Range.t()) ::
-          [{:ok, map()} | {:error, {Exception.t(), binary}}] | {:error, {Exception.t(), binary}}
+          [{:ok, t()} | {:error, {Exception.t(), binary}}] | {:error, {Exception.t(), binary}}
   def historic_rates(date) do
     Retriever.historic_rates(date)
   end

--- a/lib/money/exchange_rates/cache.ex
+++ b/lib/money/exchange_rates/cache.ex
@@ -31,6 +31,8 @@ defmodule Money.ExchangeRates.Cache do
   same pattern.
   """
 
+  alias Money.ExchangeRates
+
   @typedoc "A reference to a retriever's cache storage, returned by `c:init/1`."
   @type cache :: any()
 
@@ -60,20 +62,22 @@ defmodule Money.ExchangeRates.Cache do
   Retrieve the latest exchange rates from the
   cache.
   """
-  @callback latest_rates(cache()) :: {:ok, map()} | {:error, {Exception.t(), String.t()}}
+  @callback latest_rates(cache()) ::
+              {:ok, ExchangeRates.t()} | {:error, {Exception.t(), String.t()}}
 
   @doc deprecated: "Use latest_rates/1 instead"
-  @callback latest_rates() :: {:ok, map()} | {:error, {Exception.t(), String.t()}}
+  @callback latest_rates() :: {:ok, ExchangeRates.t()} | {:error, {Exception.t(), String.t()}}
 
   @doc """
   Retrieve the exchange rates for a given
   date.
   """
   @callback historic_rates(cache(), Date.t()) ::
-              {:ok, map()} | {:error, {Exception.t(), String.t()}}
+              {:ok, ExchangeRates.t()} | {:error, {Exception.t(), String.t()}}
 
   @doc deprecated: "Use historic_rates/2 instead"
-  @callback historic_rates(Date.t()) :: {:ok, map()} | {:error, {Exception.t(), String.t()}}
+  @callback historic_rates(Date.t()) ::
+              {:ok, ExchangeRates.t()} | {:error, {Exception.t(), String.t()}}
 
   @doc """
   Return the timestamp when the exchange rates were last updated.
@@ -86,19 +90,19 @@ defmodule Money.ExchangeRates.Cache do
   @doc """
   Store the latest exchange rates in the cache.
   """
-  @callback store_latest_rates(cache(), map(), DateTime.t()) :: :ok
+  @callback store_latest_rates(cache(), ExchangeRates.t(), DateTime.t()) :: :ok
 
   @doc deprecated: "Use store_latest_rates/3 instead"
-  @callback store_latest_rates(map(), DateTime.t()) :: :ok
+  @callback store_latest_rates(ExchangeRates.t(), DateTime.t()) :: :ok
 
   @doc """
   Store the historic exchange rates for a given
   date in the cache.
   """
-  @callback store_historic_rates(cache(), map(), Date.t()) :: :ok
+  @callback store_historic_rates(cache(), ExchangeRates.t(), Date.t()) :: :ok
 
   @doc deprecated: "Use store_historic_rates/3 instead"
-  @callback store_historic_rates(map(), Date.t()) :: :ok
+  @callback store_historic_rates(ExchangeRates.t(), Date.t()) :: :ok
 
   @optional_callbacks init: 0,
                       terminate: 0,

--- a/lib/money/exchange_rates/cache.ex
+++ b/lib/money/exchange_rates/cache.ex
@@ -1,45 +1,110 @@
 defmodule Money.ExchangeRates.Cache do
   @moduledoc """
   Defines the cache behaviour for exchange rates.
+
+  Most callbacks receive a `t:cache/0` term - the value returned by `c:init/1` -
+  identifying which retriever's storage to operate on. This allows a single
+  cache module (such as the bundled `Money.ExchangeRates.Cache.Ets` and
+  `Money.ExchangeRates.Cache.Dets`) to be shared safely by multiple named
+  retrievers, each backed by its own separated storage.
+
+  ## Migrating from the deprecated singleton callbacks
+
+  Older cache modules implemented `init/0`, `terminate/0`, `latest_rates/0`,
+  `historic_rates/1`, `last_updated/0`, `store_latest_rates/2` and
+  `store_historic_rates/2`, storing rates as fixed, module-wide state. These
+  still work (with a compiler warning), but named retrievers sharing such a
+  module overwrite each other's rates.
+
+  To migrate, add the `t:cache/0` value returned by `init/1` as the leading
+  argument to every other callback, and key storage off the `name` given to
+  `init/1` instead of a fixed identifier:
+
+      def init(name), do: :ets.new(name, [:named_table, :public])
+      def latest_rates(cache), do: :ets.lookup(cache, :latest_rates)
+      def store_latest_rates(cache, rates, retrieved_at) do
+        :ets.insert(cache, {:latest_rates, rates})
+        :ets.insert(cache, {:last_updated, retrieved_at})
+      end
+
+  `terminate/1`, `historic_rates/2` and `store_historic_rates/3` follow the
+  same pattern.
   """
+
+  @typedoc "A reference to a retriever's cache storage, returned by `c:init/1`."
+  @type cache :: any()
 
   @doc """
   Initialize the cache when the exchange rates
   retriever is started
+
+  Called with the retriever's `:name`, so that a cache module can maintain
+  separate storage per retriever. Must return a `t:cache/0` value that is
+  passed to every other callback.
   """
+  @callback init(name :: term()) :: cache()
+
+  @doc deprecated: "Use init/1 instead"
   @callback init() :: any()
 
   @doc """
   Terminate the cache when the retriever process
   stops normally
   """
+  @callback terminate(cache()) :: any()
+
+  @doc deprecated: "Use terminate/1 instead"
   @callback terminate() :: any()
 
   @doc """
   Retrieve the latest exchange rates from the
   cache.
   """
+  @callback latest_rates(cache()) :: {:ok, map()} | {:error, {Exception.t(), String.t()}}
+
+  @doc deprecated: "Use latest_rates/1 instead"
   @callback latest_rates() :: {:ok, map()} | {:error, {Exception.t(), String.t()}}
 
   @doc """
   Retrieve the exchange rates for a given
   date.
   """
+  @callback historic_rates(cache(), Date.t()) ::
+              {:ok, map()} | {:error, {Exception.t(), String.t()}}
+
+  @doc deprecated: "Use historic_rates/2 instead"
   @callback historic_rates(Date.t()) :: {:ok, map()} | {:error, {Exception.t(), String.t()}}
 
   @doc """
   Return the timestamp when the exchange rates were last updated.
   """
+  @callback last_updated(cache()) :: {:ok, DateTime.t()} | {:error, {Exception.t(), String.t()}}
+
+  @doc deprecated: "Use last_updated/1 instead"
   @callback last_updated() :: {:ok, DateTime.t()} | {:error, {Exception.t(), String.t()}}
 
   @doc """
   Store the latest exchange rates in the cache.
   """
+  @callback store_latest_rates(cache(), map(), DateTime.t()) :: :ok
+
+  @doc deprecated: "Use store_latest_rates/3 instead"
   @callback store_latest_rates(map(), DateTime.t()) :: :ok
 
   @doc """
   Store the historic exchange rates for a given
   date in the cache.
   """
+  @callback store_historic_rates(cache(), map(), Date.t()) :: :ok
+
+  @doc deprecated: "Use store_historic_rates/3 instead"
   @callback store_historic_rates(map(), Date.t()) :: :ok
+
+  @optional_callbacks init: 0,
+                      terminate: 0,
+                      latest_rates: 0,
+                      historic_rates: 1,
+                      last_updated: 0,
+                      store_latest_rates: 2,
+                      store_historic_rates: 2
 end

--- a/lib/money/exchange_rates/cache/dets.ex
+++ b/lib/money/exchange_rates/cache/dets.ex
@@ -4,37 +4,31 @@ defmodule Money.ExchangeRates.Cache.Dets do
   :dets
   """
 
-  @behaviour Money.ExchangeRates.Cache
-
-  @ets_table :exchange_rates
-
-  require Logger
-  require Money.ExchangeRates.Cache.EtsDets
-  Money.ExchangeRates.Cache.EtsDets.define_common_functions()
+  use Money.ExchangeRates.Cache.EtsDets
 
   @impl true
-  def init do
-    path = System.tmp_dir!() |> Path.join(".exchange_rates") |> String.to_charlist()
-    {:ok, name} = :dets.open_file(@ets_table, file: path)
+  def init(name) do
+    path = Path.join(System.tmp_dir!(), ".exchange_rates_#{name}")
+    {:ok, name} = :dets.open_file(name, file: String.to_charlist(path))
     name
   end
 
   @impl true
-  def terminate do
-    :dets.close(@ets_table)
+  def terminate(table) do
+    :dets.close(table)
   end
 
-  @spec get(any()) :: any()
-  def get(key) do
-    case :dets.lookup(@ets_table, key) do
-      [{^key, value}] -> value
-      [] -> nil
+  defp get(table, key) do
+    with info when is_list(info) <- :dets.info(table),
+         [{^key, value}] <- :dets.lookup(table, key) do
+      value
+    else
+      _ -> nil
     end
   end
 
-  @spec put(any(), any()) :: any()
-  def put(key, value) do
-    :dets.insert(@ets_table, {key, value})
+  defp put(table, key, value) do
+    :dets.insert(table, {key, value})
     value
   end
 end

--- a/lib/money/exchange_rates/cache/dets.ex
+++ b/lib/money/exchange_rates/cache/dets.ex
@@ -8,9 +8,9 @@ defmodule Money.ExchangeRates.Cache.Dets do
 
   @impl true
   def init(name) do
-    path = Path.join(System.tmp_dir!(), ".exchange_rates_#{name}")
-    {:ok, name} = :dets.open_file(name, file: String.to_charlist(path))
-    name
+    path = Path.join(System.tmp_dir!(), ".exchange_rates_#{:erlang.phash2(name)}")
+    {:ok, table} = :dets.open_file(name, file: String.to_charlist(path))
+    table
   end
 
   @impl true

--- a/lib/money/exchange_rates/cache/ets.ex
+++ b/lib/money/exchange_rates/cache/ets.ex
@@ -7,34 +7,24 @@ defmodule Money.ExchangeRates.Cache.Ets do
   use Money.ExchangeRates.Cache.EtsDets
 
   @impl true
-  def init(name) do
-    if :ets.info(name) == :undefined do
-      :ets.new(name, [
-        :named_table,
-        :public,
-        read_concurrency: true
-      ])
-    else
-      name
-    end
+  def init(_name) do
+    :ets.new(__MODULE__, [:public, read_concurrency: true])
   end
 
   @impl true
-  def terminate(_table) do
+  def terminate(_tid) do
     :ok
   end
 
-  defp get(table, key) do
-    with tid when tid != :undefined <- :ets.whereis(table),
-         [{^key, value}] <- :ets.lookup(tid, key) do
-      value
-    else
+  defp get(tid, key) do
+    case :ets.lookup(tid, key) do
+      [{^key, value}] -> value
       _ -> nil
     end
   end
 
-  defp put(table, key, value) do
-    :ets.insert(table, {key, value})
+  defp put(tid, key, value) do
+    :ets.insert(tid, {key, value})
     value
   end
 end

--- a/lib/money/exchange_rates/cache/ets.ex
+++ b/lib/money/exchange_rates/cache/ets.ex
@@ -4,43 +4,37 @@ defmodule Money.ExchangeRates.Cache.Ets do
   :ets
   """
 
-  @behaviour Money.ExchangeRates.Cache
-
-  @ets_table :exchange_rates
-
-  require Logger
-  require Money.ExchangeRates.Cache.EtsDets
-  Money.ExchangeRates.Cache.EtsDets.define_common_functions()
+  use Money.ExchangeRates.Cache.EtsDets
 
   @impl true
-  def init do
-    if :ets.info(@ets_table) == :undefined do
-      :ets.new(@ets_table, [
+  def init(name) do
+    if :ets.info(name) == :undefined do
+      :ets.new(name, [
         :named_table,
         :public,
         read_concurrency: true
       ])
     else
-      @ets_table
+      name
     end
   end
 
   @impl true
-  def terminate do
+  def terminate(_table) do
     :ok
   end
 
-  @spec get(any()) :: any()
-  def get(key) do
-    case :ets.lookup(@ets_table, key) do
-      [{^key, value}] -> value
-      [] -> nil
+  defp get(table, key) do
+    with tid when tid != :undefined <- :ets.whereis(table),
+         [{^key, value}] <- :ets.lookup(tid, key) do
+      value
+    else
+      _ -> nil
     end
   end
 
-  @spec put(any(), any()) :: any()
-  def put(key, value) do
-    :ets.insert(@ets_table, {key, value})
+  defp put(table, key, value) do
+    :ets.insert(table, {key, value})
     value
   end
 end

--- a/lib/money/exchange_rates/cache/ets_dets.ex
+++ b/lib/money/exchange_rates/cache/ets_dets.ex
@@ -1,16 +1,15 @@
 defmodule Money.ExchangeRates.Cache.EtsDets do
   @moduledoc false
 
-  # This macro generates several small cache functions shared by the ETS and
-  # DETS backends. Its cyclomatic complexity and ABC size are the aggregate of
-  # the generated clauses, not the complexity of any single function, so the
-  # complexity checks are disabled here.
-  # credo:disable-for-next-line
-  defmacro define_common_functions do
+  defmacro __using__(_opts) do
     quote do
+      @behaviour Money.ExchangeRates.Cache
+
+      require Logger
+
       @impl Money.ExchangeRates.Cache
-      def latest_rates do
-        case get(:latest_rates) do
+      def latest_rates(cache) do
+        case get(cache, :latest_rates) do
           nil ->
             {:error, {Money.ExchangeRateError, "No exchange rates were found"}}
 
@@ -20,8 +19,8 @@ defmodule Money.ExchangeRates.Cache.EtsDets do
       end
 
       @impl Money.ExchangeRates.Cache
-      def historic_rates(%Date{calendar: Calendar.ISO} = date) do
-        case get(date) do
+      def historic_rates(cache, %Date{calendar: Calendar.ISO} = date) do
+        case get(cache, date) do
           nil ->
             {:error,
              {Money.ExchangeRateError, "No exchange rates for #{Date.to_string(date)} were found"}}
@@ -31,14 +30,9 @@ defmodule Money.ExchangeRates.Cache.EtsDets do
         end
       end
 
-      def historic_rates(%{year: year, month: month, day: day}) do
-        {:ok, date} = Date.new(year, month, day)
-        historic_rates(date)
-      end
-
       @impl Money.ExchangeRates.Cache
-      def last_updated do
-        case get(:last_updated) do
+      def last_updated(cache) do
+        case get(cache, :last_updated) do
           nil ->
             Logger.error("Argument error getting last updated timestamp from ETS table")
             {:error, {Money.ExchangeRateError, "Last updated date is not known"}}
@@ -49,14 +43,14 @@ defmodule Money.ExchangeRates.Cache.EtsDets do
       end
 
       @impl Money.ExchangeRates.Cache
-      def store_latest_rates(rates, retrieved_at) do
-        put(:latest_rates, rates)
-        put(:last_updated, retrieved_at)
+      def store_latest_rates(cache, rates, retrieved_at) do
+        put(cache, :latest_rates, rates)
+        put(cache, :last_updated, retrieved_at)
       end
 
       @impl Money.ExchangeRates.Cache
-      def store_historic_rates(rates, date) do
-        put(date, rates)
+      def store_historic_rates(cache, rates, date) do
+        put(cache, date, rates)
       end
     end
   end

--- a/lib/money/exchange_rates/retriever.ex
+++ b/lib/money/exchange_rates/retriever.ex
@@ -28,15 +28,19 @@ defmodule Money.ExchangeRates.Retriever do
       Money.ExchangeRates.Retriever.latest_rates(:open_exchange_rates)
       Money.ExchangeRates.Retriever.historic_rates(:fixer, ~D[2024-01-01])
 
-  > #### Each named retriever needs its own cache module {: .warning}
+  > #### Named retrievers each get their own cache {: .info}
   >
   > The bundled cache implementations (`Money.ExchangeRates.Cache.Ets` and
-  > `Money.ExchangeRates.Cache.Dets`) use a fixed, module-wide storage location
-  > (the `:exchange_rates` ETS table / a single DETS file). Two retrievers
-  > configured with the same `cache_module` therefore share one cache and will
-  > overwrite each other's rates. When running multiple named retrievers, give
-  > each its own `cache_module` (a distinct module backed by a distinct ETS
-  > table name or DETS path) in its configuration.
+  > `Money.ExchangeRates.Cache.Dets`) key their storage (the ETS table name /
+  > DETS file path) by the retriever's `:name`, so multiple named retrievers
+  > can safely share the same `cache_module` - each gets its own separated
+  > cache.
+  >
+  > A custom cache module that implements only the deprecated,
+  > lower-arity `Money.ExchangeRates.Cache` callbacks behaves as a single,
+  > module-wide cache instead. Named retrievers sharing such a module will
+  > overwrite each other's rates; give each its own `cache_module` in that
+  > case.
 
   By default exchange rates are retrieved from
   [Open Exchange Rates](http://openexchangerates.org). The retrieval interval
@@ -53,7 +57,7 @@ defmodule Money.ExchangeRates.Retriever do
   @doc deprecated: "Use `Supervisor.start_child/2` on your application's supervisor instead"
   @spec start(GenServer.name(), Money.ExchangeRates.Config.t()) :: GenServer.on_start()
   def start(name \\ __MODULE__, config \\ Money.ExchangeRates.config()) do
-    GenServer.start_link(__MODULE__, config, name: name)
+    GenServer.start_link(__MODULE__, %{config: config, name: name}, name: name)
   end
 
   @doc deprecated: "Use `Supervisor.terminate_child/2` on your application's supervisor instead"
@@ -80,7 +84,7 @@ defmodule Money.ExchangeRates.Retriever do
   def start_link(opts \\ []) do
     config = Keyword.get(opts, :config, Money.ExchangeRates.config())
     name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, config, name: name)
+    GenServer.start_link(__MODULE__, %{config: config, name: name}, name: name)
   end
 
   @doc """
@@ -303,9 +307,10 @@ defmodule Money.ExchangeRates.Retriever do
   #
 
   @impl true
-  def init(config) do
+  def init(%{config: config, name: name} = state) do
     :erlang.process_flag(:trap_exit, true)
-    config.cache_module.init()
+    cache = call_cache_module(config, :init, [name])
+    state = Map.put(state, :cache, cache)
 
     if is_integer(config.retrieve_every) do
       log(config, :info, log_init_message(config.retrieve_every))
@@ -314,112 +319,113 @@ defmodule Money.ExchangeRates.Retriever do
 
     if config.preload_historic_rates do
       log(config, :info, "Preloading historic rates for #{inspect(config.preload_historic_rates)}")
-      schedule_historic_rates_preload(config.preload_historic_rates, config.cache_module)
+      schedule_historic_rates_preload(config.preload_historic_rates, state)
     end
 
-    {:ok, config}
+    {:ok, state}
   end
 
   @impl true
-  def terminate(:normal, config) do
-    config.cache_module.terminate()
+  def terminate(:normal, state) do
+    call_cache_module(state.config, :terminate, [state.cache])
   end
 
   @impl true
-  def terminate(:shutdown, config) do
-    config.cache_module.terminate()
+  def terminate(:shutdown, state) do
+    call_cache_module(state.config, :terminate, [state.cache])
   end
 
   @impl true
-  def terminate(other, _config) do
+  def terminate(other, _state) do
     Logger.error("[ExchangeRates.Retriever] Terminate called with unhandled #{inspect(other)}")
   end
 
   @impl true
-  def handle_call(:latest_rates, _from, config) do
-    {:reply, retrieve_latest_rates(config), config}
+  def handle_call(:latest_rates, _from, state) do
+    {:reply, retrieve_latest_rates(state), state}
   end
 
   @impl true
-  def handle_call({:historic_rates, date}, _from, config) do
-    {:reply, retrieve_historic_rates(date, config), config}
+  def handle_call({:historic_rates, date}, _from, state) do
+    {:reply, retrieve_historic_rates(date, state), state}
   end
 
-  def handle_call(:latest_rates_available?, _from, config) do
-    {:reply, match?({:ok, _rates}, config.cache_module.latest_rates()), config}
+  def handle_call(:latest_rates_available?, _from, state) do
+    {:reply, match?({:ok, _rates}, call_cache_module(state.config, :latest_rates, [state.cache])),
+     state}
   end
 
-  def handle_call(:last_updated, _from, config) do
-    {:reply, config.cache_module.last_updated(), config}
-  end
-
-  @impl true
-  def handle_call({:reconfigure, new_configuration}, _from, config) do
-    config.cache_module.terminate()
-    {:ok, new_config} = init(new_configuration)
-    {:reply, new_config, new_config}
+  def handle_call(:last_updated, _from, state) do
+    {:reply, call_cache_module(state.config, :last_updated, [state.cache]), state}
   end
 
   @impl true
-  def handle_call(:config, _from, config) do
-    {:reply, config, config}
+  def handle_call({:reconfigure, new_configuration}, _from, state) do
+    call_cache_module(state.config, :terminate, [state.cache])
+    {:ok, new_state} = init(%{config: new_configuration, name: state.name})
+    {:reply, new_state.config, new_state}
   end
 
   @impl true
-  def handle_call(:stop, _from, config) do
-    {:stop, :normal, :ok, config}
+  def handle_call(:config, _from, state) do
+    {:reply, state.config, state}
   end
 
   @impl true
-  def handle_call({:stop, reason}, _from, config) do
-    {:stop, reason, :ok, config}
+  def handle_call(:stop, _from, state) do
+    {:stop, :normal, :ok, state}
   end
 
   @impl true
-  def handle_info(:scheduled_latest_rates_fetch, config) do
-    fetch_latest_rates(config)
-    schedule_latest_rates_fetch(config.retrieve_every)
-    {:noreply, config}
+  def handle_call({:stop, reason}, _from, state) do
+    {:stop, reason, :ok, state}
   end
 
   @impl true
-  def handle_info({:historic_rates, %Date{calendar: Calendar.ISO} = date}, config) do
-    retrieve_historic_rates(date, config)
-    {:noreply, config}
+  def handle_info(:scheduled_latest_rates_fetch, state) do
+    fetch_latest_rates(state)
+    schedule_latest_rates_fetch(state.config.retrieve_every)
+    {:noreply, state}
   end
 
   @impl true
-  def handle_info(:stop, config) do
-    {:stop, :normal, config}
+  def handle_info({:historic_rates, %Date{calendar: Calendar.ISO} = date}, state) do
+    retrieve_historic_rates(date, state)
+    {:noreply, state}
   end
 
   @impl true
-  def handle_info({:stop, reason}, config) do
-    {:stop, reason, config}
+  def handle_info(:stop, state) do
+    {:stop, :normal, state}
   end
 
   @impl true
-  def handle_info(message, config) do
+  def handle_info({:stop, reason}, state) do
+    {:stop, reason, state}
+  end
+
+  @impl true
+  def handle_info(message, state) do
     Logger.error("Invalid message for ExchangeRates.Retriever: #{inspect(message)}")
-    {:noreply, config}
+    {:noreply, state}
   end
 
-  defp retrieve_latest_rates(config) do
-    case config.cache_module.latest_rates() do
+  defp retrieve_latest_rates(state) do
+    case call_cache_module(state.config, :latest_rates, [state.cache]) do
       {:ok, rates} -> {:ok, rates}
-      {:error, _reason} -> fetch_latest_rates(config)
+      {:error, _reason} -> fetch_latest_rates(state)
     end
   end
 
-  defp fetch_latest_rates(config) do
+  defp fetch_latest_rates(%{config: config} = state) do
     case call_api_module(config, :get_latest_rates, [config]) do
       {:ok, :not_modified} ->
         log(config, :success, "Retrieved latest exchange rates successfully. Rates unchanged.")
-        config.cache_module.latest_rates()
+        call_cache_module(config, :latest_rates, [state.cache])
 
       {:ok, rates} ->
         retrieved_at = DateTime.utc_now()
-        config.cache_module.store_latest_rates(rates, retrieved_at)
+        call_cache_module(config, :store_latest_rates, [state.cache, rates, retrieved_at])
         run_callback(config, :latest_rates_retrieved, [rates, retrieved_at])
         log(config, :success, "Retrieved latest exchange rates successfully")
         {:ok, rates}
@@ -430,21 +436,21 @@ defmodule Money.ExchangeRates.Retriever do
     end
   end
 
-  defp retrieve_historic_rates(date, config) do
-    case config.cache_module.historic_rates(date) do
+  defp retrieve_historic_rates(date, state) do
+    case call_cache_module(state.config, :historic_rates, [state.cache, date]) do
       {:ok, rates} -> {:ok, rates}
-      {:error, _reason} -> fetch_historic_rates(date, config)
+      {:error, _reason} -> fetch_historic_rates(date, state)
     end
   end
 
-  defp fetch_historic_rates(date, config) do
+  defp fetch_historic_rates(date, %{config: config} = state) do
     case call_api_module(config, :get_historic_rates, [date, config]) do
       {:ok, :not_modified} ->
         log(config, :success, "Historic exchange rates for #{Date.to_string(date)} unchanged")
-        config.cache_module.historic_rates(date)
+        call_cache_module(config, :historic_rates, [state.cache, date])
 
       {:ok, rates} ->
-        config.cache_module.store_historic_rates(rates, date)
+        call_cache_module(config, :store_historic_rates, [state.cache, rates, date])
         run_callback(config, :historic_rates_retrieved, [rates, date])
 
         log(
@@ -464,6 +470,21 @@ defmodule Money.ExchangeRates.Retriever do
         )
 
         {:error, reason}
+    end
+  end
+
+  # Calls a `Money.ExchangeRates.Cache` operation on `cache_module`. `args` is
+  # the argument list for the current, cache-taking arity (cache reference or
+  # retriever name first); if `cache_module` doesn't export that arity it
+  # falls back to the deprecated, module-wide singleton arity by dropping
+  # that leading argument.
+  defp call_cache_module(%{cache_module: cache_module}, fun, args) do
+    Code.ensure_loaded!(cache_module)
+
+    if function_exported?(cache_module, fun, length(args)) do
+      apply(cache_module, fun, args)
+    else
+      apply(cache_module, fun, tl(args))
     end
   end
 
@@ -506,9 +527,9 @@ defmodule Money.ExchangeRates.Retriever do
     Process.send_after(self(), :scheduled_latest_rates_fetch, delay_ms)
   end
 
-  defp schedule_historic_rates_preload(%Date.Range{} = date_range, cache_module) do
+  defp schedule_historic_rates_preload(%Date.Range{} = date_range, state) do
     for date <- date_range do
-      schedule_historic_rates_preload(date, cache_module)
+      schedule_historic_rates_preload(date, state)
     end
   end
 
@@ -524,8 +545,8 @@ defmodule Money.ExchangeRates.Retriever do
   # external API calls and it means the cache
   # will survive restarts both intentional and
   # unintentional
-  defp schedule_historic_rates_preload(%Date{calendar: Calendar.ISO} = date, cache_module) do
-    case cache_module.historic_rates(date) do
+  defp schedule_historic_rates_preload(%Date{calendar: Calendar.ISO} = date, state) do
+    case call_cache_module(state.config, :historic_rates, [state.cache, date]) do
       {:ok, _rates} ->
         :ok
 
@@ -534,21 +555,21 @@ defmodule Money.ExchangeRates.Retriever do
     end
   end
 
-  defp schedule_historic_rates_preload({%Date{} = from, %Date{} = to}, cache_module) do
-    schedule_historic_rates_preload(Date.range(from, to), cache_module)
+  defp schedule_historic_rates_preload({%Date{} = from, %Date{} = to}, state) do
+    schedule_historic_rates_preload(Date.range(from, to), state)
   end
 
-  defp schedule_historic_rates_preload(date_string, cache_module) when is_binary(date_string) do
+  defp schedule_historic_rates_preload(date_string, state) when is_binary(date_string) do
     parts = String.split(date_string, "..")
 
     case parts do
       [date] ->
-        schedule_historic_rates_preload(Date.from_iso8601(date), cache_module)
+        schedule_historic_rates_preload(Date.from_iso8601(date), state)
 
       [from, to] ->
         schedule_historic_rates_preload(
           {Date.from_iso8601(from), Date.from_iso8601(to)},
-          cache_module
+          state
         )
     end
   end
@@ -556,7 +577,7 @@ defmodule Money.ExchangeRates.Retriever do
   # Any non-numeric value, or non-date value means
   # we don't schedule work - ie there is no periodic
   # retrieval
-  defp schedule_historic_rates_preload(_, _cache_module) do
+  defp schedule_historic_rates_preload(_, _state) do
     :ok
   end
 

--- a/lib/money/exchange_rates/retriever.ex
+++ b/lib/money/exchange_rates/retriever.ex
@@ -56,6 +56,10 @@ defmodule Money.ExchangeRates.Retriever do
 
   alias Money.ExchangeRates
 
+  # A `GenServer.server/0`: a pid, a locally registered atom, or a
+  # `{:global, _}` / `{:via, _, _}` / `{atom, node}` tuple.
+  defguardp is_retriever(name) when is_atom(name) or is_pid(name) or is_tuple(name)
+
   @doc deprecated: "Use `Supervisor.start_child/2` on your application's supervisor instead"
   @spec start(GenServer.name(), ExchangeRates.Config.t()) :: GenServer.on_start()
   def start(name \\ __MODULE__, config \\ ExchangeRates.config()) do
@@ -109,7 +113,7 @@ defmodule Money.ExchangeRates.Retriever do
   @spec latest_rates(GenServer.server()) ::
           {:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}
   def latest_rates(retriever \\ __MODULE__) do
-    case Process.whereis(retriever) do
+    case GenServer.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
       pid -> GenServer.call(pid, :latest_rates)
     end
@@ -151,15 +155,15 @@ defmodule Money.ExchangeRates.Retriever do
   @spec historic_rates(GenServer.server(), Calendar.date()) ::
           {:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}
   def historic_rates(retriever, %Date{calendar: Calendar.ISO} = date)
-      when is_atom(retriever) or is_pid(retriever) do
-    case Process.whereis(retriever) do
+      when is_retriever(retriever) do
+    case GenServer.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
       pid -> GenServer.call(pid, {:historic_rates, date})
     end
   end
 
   def historic_rates(retriever, %{year: year, month: month, day: day})
-      when is_atom(retriever) or is_pid(retriever) do
+      when is_retriever(retriever) do
     case Date.new(year, month, day) do
       {:ok, date} -> historic_rates(retriever, date)
       error -> error
@@ -170,7 +174,7 @@ defmodule Money.ExchangeRates.Retriever do
           [{:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}]
           | {:error, {Exception.t(), binary}}
   def historic_rates(retriever, %Date.Range{} = range) do
-    case Process.whereis(retriever) do
+    case GenServer.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
       _pid -> for date <- range, do: historic_rates(retriever, date)
     end
@@ -229,7 +233,7 @@ defmodule Money.ExchangeRates.Retriever do
   """
   @spec latest_rates_available?(GenServer.server()) :: boolean
   def latest_rates_available?(retriever \\ __MODULE__) do
-    case Process.whereis(retriever) do
+    case GenServer.whereis(retriever) do
       nil -> false
       pid -> GenServer.call(pid, :latest_rates_available?)
     end
@@ -248,7 +252,7 @@ defmodule Money.ExchangeRates.Retriever do
   """
   @spec last_updated(GenServer.server()) :: {:ok, DateTime.t()} | {:error, {Exception.t(), binary}}
   def last_updated(retriever \\ __MODULE__) do
-    case Process.whereis(retriever) do
+    case GenServer.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
       pid -> GenServer.call(pid, :last_updated)
     end
@@ -262,7 +266,7 @@ defmodule Money.ExchangeRates.Retriever do
   @spec reconfigure(GenServer.name(), ExchangeRates.Config.t()) ::
           ExchangeRates.Config.t() | {:error, {module(), String.t()}}
   def reconfigure(retriever \\ __MODULE__, %ExchangeRates.Config{} = config) do
-    case Process.whereis(retriever) do
+    case GenServer.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
       pid -> GenServer.call(pid, {:reconfigure, config})
     end
@@ -276,7 +280,7 @@ defmodule Money.ExchangeRates.Retriever do
   @spec config(GenServer.name()) ::
           ExchangeRates.Config.t() | {:error, {module(), String.t()}}
   def config(retriever \\ __MODULE__) do
-    case Process.whereis(retriever) do
+    case GenServer.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
       pid -> GenServer.call(pid, :config)
     end

--- a/lib/money/exchange_rates/retriever.ex
+++ b/lib/money/exchange_rates/retriever.ex
@@ -54,9 +54,11 @@ defmodule Money.ExchangeRates.Retriever do
   use GenServer
   require Logger
 
+  alias Money.ExchangeRates
+
   @doc deprecated: "Use `Supervisor.start_child/2` on your application's supervisor instead"
-  @spec start(GenServer.name(), Money.ExchangeRates.Config.t()) :: GenServer.on_start()
-  def start(name \\ __MODULE__, config \\ Money.ExchangeRates.config()) do
+  @spec start(GenServer.name(), ExchangeRates.Config.t()) :: GenServer.on_start()
+  def start(name \\ __MODULE__, config \\ ExchangeRates.config()) do
     GenServer.start_link(__MODULE__, %{config: config, name: name}, name: name)
   end
 
@@ -82,7 +84,7 @@ defmodule Money.ExchangeRates.Retriever do
   @doc false
   @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    config = Keyword.get(opts, :config, Money.ExchangeRates.config())
+    config = Keyword.get(opts, :config, ExchangeRates.config())
     name = Keyword.get(opts, :name, __MODULE__)
     GenServer.start_link(__MODULE__, %{config: config, name: name}, name: name)
   end
@@ -104,7 +106,8 @@ defmodule Money.ExchangeRates.Retriever do
   `Money.ExchangeRates.historic_rates/1`.
 
   """
-  @spec latest_rates(GenServer.server()) :: {:ok, map()} | {:error, {Exception.t(), binary}}
+  @spec latest_rates(GenServer.server()) ::
+          {:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}
   def latest_rates(retriever \\ __MODULE__) do
     case Process.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
@@ -136,15 +139,17 @@ defmodule Money.ExchangeRates.Retriever do
 
   """
 
-  @spec historic_rates(Calendar.date()) :: {:ok, map()} | {:error, {Exception.t(), binary}}
+  @spec historic_rates(Calendar.date()) ::
+          {:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}
   @spec historic_rates(Date.Range.t()) ::
-          [{:ok, map()} | {:error, {Exception.t(), binary}}] | {:error, {Exception.t(), binary}}
+          [{:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}]
+          | {:error, {Exception.t(), binary}}
   def historic_rates(date_or_range) when is_map(date_or_range) do
     historic_rates(__MODULE__, date_or_range)
   end
 
   @spec historic_rates(GenServer.server(), Calendar.date()) ::
-          {:ok, map()} | {:error, {Exception.t(), binary}}
+          {:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}
   def historic_rates(retriever, %Date{calendar: Calendar.ISO} = date)
       when is_atom(retriever) or is_pid(retriever) do
     case Process.whereis(retriever) do
@@ -162,7 +167,8 @@ defmodule Money.ExchangeRates.Retriever do
   end
 
   @spec historic_rates(GenServer.server(), Date.Range.t()) ::
-          [{:ok, map()} | {:error, {Exception.t(), binary}}] | {:error, {Exception.t(), binary}}
+          [{:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}]
+          | {:error, {Exception.t(), binary}}
   def historic_rates(retriever, %Date.Range{} = range) do
     case Process.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
@@ -189,13 +195,15 @@ defmodule Money.ExchangeRates.Retriever do
 
   """
   @spec historic_rates(Calendar.date(), Calendar.date()) ::
-          [{:ok, map()} | {:error, {Exception.t(), binary}}] | {:error, {Exception.t(), binary}}
+          [{:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}]
+          | {:error, {Exception.t(), binary}}
   def historic_rates(from, to) when is_map(from) and is_map(to) do
     historic_rates(__MODULE__, from, to)
   end
 
   @spec historic_rates(GenServer.server(), Calendar.date(), Calendar.date()) ::
-          [{:ok, map()} | {:error, {Exception.t(), binary}}] | {:error, {Exception.t(), binary}}
+          [{:ok, ExchangeRates.t()} | {:error, {Exception.t(), binary}}]
+          | {:error, {Exception.t(), binary}}
   def historic_rates(
         retriever,
         %Date{calendar: Calendar.ISO} = from,
@@ -251,9 +259,9 @@ defmodule Money.ExchangeRates.Retriever do
   Service
 
   """
-  @spec reconfigure(GenServer.name(), Money.ExchangeRates.Config.t()) ::
-          Money.ExchangeRates.Config.t() | {:error, {module(), String.t()}}
-  def reconfigure(retriever \\ __MODULE__, %Money.ExchangeRates.Config{} = config) do
+  @spec reconfigure(GenServer.name(), ExchangeRates.Config.t()) ::
+          ExchangeRates.Config.t() | {:error, {module(), String.t()}}
+  def reconfigure(retriever \\ __MODULE__, %ExchangeRates.Config{} = config) do
     case Process.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
       pid -> GenServer.call(pid, {:reconfigure, config})
@@ -266,7 +274,7 @@ defmodule Money.ExchangeRates.Retriever do
 
   """
   @spec config(GenServer.name()) ::
-          Money.ExchangeRates.Config.t() | {:error, {module(), String.t()}}
+          ExchangeRates.Config.t() | {:error, {module(), String.t()}}
   def config(retriever \\ __MODULE__) do
     case Process.whereis(retriever) do
       nil -> {:error, exchange_rate_service_error()}
@@ -276,7 +284,7 @@ defmodule Money.ExchangeRates.Retriever do
 
   @doc deprecated:
          "Use `Money.ExchangeRates.HTTP` or the HTTP client of your preference directly instead"
-  @spec retrieve_rates(charlist() | String.t(), Money.ExchangeRates.Config.t()) ::
+  @spec retrieve_rates(charlist() | String.t(), ExchangeRates.Config.t()) ::
           {:ok, map() | :not_modified} | {:error, term()}
   def retrieve_rates(url, config) when is_list(url) do
     url
@@ -286,7 +294,7 @@ defmodule Money.ExchangeRates.Retriever do
 
   def retrieve_rates(url, config) when is_binary(url) do
     url
-    |> Money.ExchangeRates.HTTP.get(verify_peer: Map.get(config, :verify_peer, true))
+    |> ExchangeRates.HTTP.get(verify_peer: Map.get(config, :verify_peer, true))
     |> process_response(config)
   end
 

--- a/lib/money/exchange_rates/supervisor.ex
+++ b/lib/money/exchange_rates/supervisor.ex
@@ -1,29 +1,35 @@
 defmodule Money.ExchangeRates.Supervisor do
-  @moduledoc deprecated: """
-             `Money.ExchangeRates.Supervisor` is deprecated. Add `Money.ExchangeRates.Retriever`
-             directly to your application's supervision tree instead:
+  @moduledoc """
+  Supervises the exchange rates retrieval service.
 
-             ```
-             children = [
-               Money.ExchangeRates.Retriever
-             ]
-             ```
-
-             If your callback module depends on other applications being started first, position
-             `Money.ExchangeRates.Retriever` after those dependencies in the children list.
-             """
+  > #### Deprecated {: .warning}
+  >
+  > Add `Money.ExchangeRates.Retriever` directly to your application's
+  > supervision tree instead:
+  >
+  > ```elixir
+  > children = [
+  >   Money.ExchangeRates.Retriever
+  > ]
+  > ```
+  >
+  > If your callback module depends on other applications being started first,
+  > position `Money.ExchangeRates.Retriever` after those dependencies in the
+  > children list.
+  """
+  @moduledoc deprecated: "Add `Money.ExchangeRates.Retriever` to your supervision tree directly"
 
   use Supervisor
   alias Money.ExchangeRates.Retriever
 
-  @doc deprecated: "Add `Money.ExchangeRates.Retriever` to your supervision tree directly."
+  @doc deprecated: "Add `Money.ExchangeRates.Retriever` to your supervision tree directly"
   @spec start_link(Keyword.t()) :: Supervisor.on_start()
   def start_link(options) do
     if Keyword.get(options, :restart, false), do: stop()
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
-  @doc deprecated: "Manage `Money.ExchangeRates.Retriever` directly in your supervision tree."
+  @doc deprecated: "Manage `Money.ExchangeRates.Retriever` directly in your supervision tree"
   @spec stop(Supervisor.supervisor()) :: :ok | {:error, :not_found}
   def stop(supervisor \\ default_supervisor()) do
     Supervisor.terminate_child(supervisor, __MODULE__)
@@ -45,14 +51,14 @@ defmodule Money.ExchangeRates.Supervisor do
     Supervisor.init([Retriever], strategy: :one_for_one)
   end
 
-  @doc deprecated: "Use `Process.whereis(Money.ExchangeRates.Retriever)` directly."
+  @doc deprecated: "Use `Process.whereis(Money.ExchangeRates.Retriever)` directly"
   @spec retriever_running?() :: boolean()
   def retriever_running? do
     !!Process.whereis(Retriever)
   end
 
   @doc deprecated:
-         "Use `Process.whereis(Money.ExchangeRates.Retriever)` to check if the retriever is running."
+         "Use `Process.whereis(Money.ExchangeRates.Retriever)` to check if the retriever is running"
   @spec retriever_status() :: :running | :stopped | :not_started
   def retriever_status do
     cond do
@@ -68,21 +74,21 @@ defmodule Money.ExchangeRates.Supervisor do
     |> Enum.any?(fn {name, _pid, _type, _args} -> name == child end)
   end
 
-  @doc deprecated: "Add `Money.ExchangeRates.Retriever` to your supervision tree directly."
+  @doc deprecated: "Add `Money.ExchangeRates.Retriever` to your supervision tree directly"
   @spec start_retriever(Money.ExchangeRates.Config.t()) :: Supervisor.on_start_child()
   def start_retriever(config \\ Money.ExchangeRates.config()) do
     Supervisor.start_child(__MODULE__, {Retriever, [config: config]})
   end
 
   @doc deprecated:
-         "Migrate to managing `Money.ExchangeRates.Retriever` in your own supervision tree, then use your supervisor's `terminate_child/2`."
+         "Migrate to managing `Money.ExchangeRates.Retriever` in your own supervision tree, then use your supervisor's `terminate_child/2`"
   @spec stop_retriever() :: :ok | {:error, :not_found}
   def stop_retriever do
     Supervisor.terminate_child(__MODULE__, Retriever)
   end
 
   @doc deprecated:
-         "Migrate to managing `Money.ExchangeRates.Retriever` in your own supervision tree, then use your supervisor's `restart_child/2`."
+         "Migrate to managing `Money.ExchangeRates.Retriever` in your own supervision tree, then use your supervisor's `restart_child/2`"
   @spec restart_retriever() ::
           {:ok, pid() | :undefined} | {:ok, pid() | :undefined, term()} | {:error, term()}
   def restart_retriever do
@@ -90,7 +96,7 @@ defmodule Money.ExchangeRates.Supervisor do
   end
 
   @doc deprecated:
-         "Migrate to managing `Money.ExchangeRates.Retriever` in your own supervision tree, then use your supervisor's `delete_child/2`."
+         "Migrate to managing `Money.ExchangeRates.Retriever` in your own supervision tree, then use your supervisor's `delete_child/2`"
   @spec delete_retriever() :: :ok | {:error, :not_found | :restarting | :running}
   def delete_retriever do
     Supervisor.delete_child(__MODULE__, Retriever)

--- a/test/money/exchange_rates/cache/dets_test.exs
+++ b/test/money/exchange_rates/cache/dets_test.exs
@@ -9,67 +9,68 @@ defmodule Money.ExchangeRates.Cache.DetsTest do
   @date ~D[2099-02-01]
 
   setup do
-    Dets.init()
+    name = :"dets_test_#{System.unique_integer([:positive])}"
+    cache = Dets.init(name)
 
-    on_exit(fn -> Dets.terminate() end)
+    on_exit(fn -> Dets.terminate(cache) end)
 
-    :ok
+    {:ok, cache: cache}
   end
 
-  describe "init/0" do
-    test "returns the table name" do
-      assert Dets.init() == :exchange_rates
+  describe "init/1" do
+    test "returns the table name", %{cache: cache} do
+      assert is_atom(cache)
     end
   end
 
-  describe "terminate/0" do
-    test "returns :ok" do
-      assert Dets.terminate() == :ok
+  describe "terminate/1" do
+    test "returns :ok", %{cache: cache} do
+      assert Dets.terminate(cache) == :ok
     end
   end
 
-  describe "store_latest_rates/2 and latest_rates/0" do
-    test "returns stored rates" do
+  describe "store_latest_rates/3 and latest_rates/1" do
+    test "returns stored rates", %{cache: cache} do
       retrieved_at = DateTime.utc_now()
-      Dets.store_latest_rates(@rates, retrieved_at)
-      assert Dets.latest_rates() == {:ok, @rates}
+      Dets.store_latest_rates(cache, @rates, retrieved_at)
+      assert Dets.latest_rates(cache) == {:ok, @rates}
     end
   end
 
-  describe "store_historic_rates/2 and historic_rates/1" do
-    test "returns stored rates for a Date" do
-      Dets.store_historic_rates(@rates, @date)
-      assert Dets.historic_rates(@date) == {:ok, @rates}
+  describe "store_historic_rates/3 and historic_rates/2" do
+    test "returns stored rates for a Date", %{cache: cache} do
+      Dets.store_historic_rates(cache, @rates, @date)
+      assert Dets.historic_rates(cache, @date) == {:ok, @rates}
     end
 
-    test "returns an error for an unstored date" do
-      assert Dets.historic_rates(~D[2099-12-30]) ==
+    test "returns an error for an unstored date", %{cache: cache} do
+      assert Dets.historic_rates(cache, ~D[2099-12-30]) ==
                {:error, {Money.ExchangeRateError, "No exchange rates for 2099-12-30 were found"}}
     end
   end
 
-  describe "last_updated/0" do
-    test "returns the timestamp stored alongside the latest rates" do
+  describe "last_updated/1" do
+    test "returns the timestamp stored alongside the latest rates", %{cache: cache} do
       retrieved_at = DateTime.utc_now()
-      Dets.store_latest_rates(@rates, retrieved_at)
-      assert Dets.last_updated() == {:ok, retrieved_at}
+      Dets.store_latest_rates(cache, @rates, retrieved_at)
+      assert Dets.last_updated(cache) == {:ok, retrieved_at}
     end
   end
 
   describe "persistence across restarts" do
-    test "latest rates survive terminate/init cycle" do
+    test "latest rates survive terminate/init cycle", %{cache: cache} do
       retrieved_at = DateTime.utc_now()
-      Dets.store_latest_rates(@rates, retrieved_at)
-      Dets.terminate()
-      Dets.init()
-      assert Dets.latest_rates() == {:ok, @rates}
+      Dets.store_latest_rates(cache, @rates, retrieved_at)
+      Dets.terminate(cache)
+      cache = Dets.init(cache)
+      assert Dets.latest_rates(cache) == {:ok, @rates}
     end
 
-    test "historic rates survive terminate/init cycle" do
-      Dets.store_historic_rates(@rates, @date)
-      Dets.terminate()
-      Dets.init()
-      assert Dets.historic_rates(@date) == {:ok, @rates}
+    test "historic rates survive terminate/init cycle", %{cache: cache} do
+      Dets.store_historic_rates(cache, @rates, @date)
+      Dets.terminate(cache)
+      cache = Dets.init(cache)
+      assert Dets.historic_rates(cache, @date) == {:ok, @rates}
     end
   end
 end

--- a/test/money/exchange_rates/cache/dets_test.exs
+++ b/test/money/exchange_rates/cache/dets_test.exs
@@ -18,8 +18,12 @@ defmodule Money.ExchangeRates.Cache.DetsTest do
   end
 
   describe "init/1" do
-    test "returns the table name", %{cache: cache} do
-      assert is_atom(cache)
+    test "accepts a non-atom name and returns a usable handle" do
+      cache = Dets.init({:via, Registry, {SomeRegistry, :bid}})
+      on_exit(fn -> Dets.terminate(cache) end)
+
+      Dets.store_latest_rates(cache, @rates, DateTime.utc_now())
+      assert Dets.latest_rates(cache) == {:ok, @rates}
     end
   end
 

--- a/test/money/exchange_rates/cache/ets_test.exs
+++ b/test/money/exchange_rates/cache/ets_test.exs
@@ -9,47 +9,55 @@ defmodule Money.ExchangeRates.Cache.EtsTest do
   @date ~D[2099-01-01]
 
   setup do
-    Ets.init()
-    :ok
+    name = :"ets_test_#{System.unique_integer([:positive])}"
+    cache = Ets.init(name)
+
+    {:ok, cache: cache}
   end
 
-  describe "init/0" do
-    test "returns the table name when the table already exists" do
-      assert Ets.init() == :exchange_rates
+  describe "init/1" do
+    test "returns a usable ETS table reference", %{cache: cache} do
+      assert :ets.info(cache) != :undefined
+    end
+
+    test "reuses an existing table instead of raising", %{cache: cache} do
+      assert Ets.init(cache) == cache
+      assert :ets.info(cache) != :undefined
     end
   end
 
-  describe "terminate/0" do
-    test "returns :ok" do
-      assert Ets.terminate() == :ok
+  describe "terminate/1" do
+    test "is a no-op that leaves the underlying table intact", %{cache: cache} do
+      assert Ets.terminate(cache) == :ok
+      assert :ets.info(cache) != :undefined
     end
   end
 
-  describe "store_latest_rates/2 and latest_rates/0" do
-    test "returns stored rates" do
+  describe "store_latest_rates/3 and latest_rates/1" do
+    test "returns stored rates", %{cache: cache} do
       retrieved_at = DateTime.utc_now()
-      Ets.store_latest_rates(@rates, retrieved_at)
-      assert Ets.latest_rates() == {:ok, @rates}
+      Ets.store_latest_rates(cache, @rates, retrieved_at)
+      assert Ets.latest_rates(cache) == {:ok, @rates}
     end
   end
 
-  describe "store_historic_rates/2 and historic_rates/1" do
-    test "returns stored rates for a Date" do
-      Ets.store_historic_rates(@rates, @date)
-      assert Ets.historic_rates(@date) == {:ok, @rates}
+  describe "store_historic_rates/3 and historic_rates/2" do
+    test "returns stored rates for a Date", %{cache: cache} do
+      Ets.store_historic_rates(cache, @rates, @date)
+      assert Ets.historic_rates(cache, @date) == {:ok, @rates}
     end
 
-    test "returns an error for an unstored date" do
-      assert Ets.historic_rates(~D[2099-12-31]) ==
+    test "returns an error for an unstored date", %{cache: cache} do
+      assert Ets.historic_rates(cache, ~D[2099-12-31]) ==
                {:error, {Money.ExchangeRateError, "No exchange rates for 2099-12-31 were found"}}
     end
   end
 
-  describe "last_updated/0" do
-    test "returns the timestamp stored alongside the latest rates" do
+  describe "last_updated/1" do
+    test "returns the timestamp stored alongside the latest rates", %{cache: cache} do
       retrieved_at = DateTime.utc_now()
-      Ets.store_latest_rates(@rates, retrieved_at)
-      assert Ets.last_updated() == {:ok, retrieved_at}
+      Ets.store_latest_rates(cache, @rates, retrieved_at)
+      assert Ets.last_updated(cache) == {:ok, retrieved_at}
     end
   end
 end

--- a/test/money/exchange_rates/cache/ets_test.exs
+++ b/test/money/exchange_rates/cache/ets_test.exs
@@ -9,27 +9,35 @@ defmodule Money.ExchangeRates.Cache.EtsTest do
   @date ~D[2099-01-01]
 
   setup do
-    name = :"ets_test_#{System.unique_integer([:positive])}"
-    cache = Ets.init(name)
+    cache = Ets.init(:"ets_test_#{System.unique_integer([:positive])}")
 
     {:ok, cache: cache}
   end
 
   describe "init/1" do
-    test "returns a usable ETS table reference", %{cache: cache} do
-      assert :ets.info(cache) != :undefined
+    test "accepts a non-atom name and returns a usable handle" do
+      cache = Ets.init({:via, Registry, {SomeRegistry, :bid}})
+
+      retrieved_at = DateTime.utc_now()
+      Ets.store_latest_rates(cache, @rates, retrieved_at)
+      assert Ets.latest_rates(cache) == {:ok, @rates}
     end
 
-    test "reuses an existing table instead of raising", %{cache: cache} do
-      assert Ets.init(cache) == cache
-      assert :ets.info(cache) != :undefined
+    test "returns an isolated cache on each call" do
+      other = Ets.init(:"ets_test_#{System.unique_integer([:positive])}")
+
+      Ets.store_latest_rates(other, @rates, DateTime.utc_now())
+
+      assert Ets.latest_rates(other) == {:ok, @rates}
+
+      assert Ets.latest_rates(Ets.init(:another)) ==
+               {:error, {Money.ExchangeRateError, "No exchange rates were found"}}
     end
   end
 
   describe "terminate/1" do
-    test "is a no-op that leaves the underlying table intact", %{cache: cache} do
+    test "returns :ok", %{cache: cache} do
       assert Ets.terminate(cache) == :ok
-      assert :ets.info(cache) != :undefined
     end
   end
 

--- a/test/money/exchange_rates/retriever_test.exs
+++ b/test/money/exchange_rates/retriever_test.exs
@@ -7,6 +7,38 @@ defmodule Money.ExchangeRates.RetrieverTest do
 
   doctest Retriever
 
+  # A `Money.ExchangeRates.Cache` implementation using only the deprecated,
+  # arity-0 (module-wide singleton) callbacks, to prove the retriever still
+  # works against a cache module written for the pre-named-retriever API.
+  # Static, cache-always-misses values keep this focused on dispatch, not
+  # on being a real cache.
+  defmodule LegacyCacheMock do
+    @moduledoc false
+    @behaviour Money.ExchangeRates.Cache
+
+    @impl true
+    def init, do: :ok
+
+    @impl true
+    def terminate, do: :ok
+
+    @impl true
+    def latest_rates, do: {:error, {Money.ExchangeRateError, "No exchange rates were found"}}
+
+    @impl true
+    def historic_rates(_date),
+      do: {:error, {Money.ExchangeRateError, "No exchange rates were found"}}
+
+    @impl true
+    def last_updated, do: {:error, {Money.ExchangeRateError, "Last updated date is not known"}}
+
+    @impl true
+    def store_latest_rates(_rates, _retrieved_at), do: :ok
+
+    @impl true
+    def store_historic_rates(_rates, _date), do: :ok
+  end
+
   setup do
     Application.put_env(:ex_money, :exchange_rates_http_client, Money.ExchangeRatesHttpMock)
     start_supervised!(Retriever)
@@ -245,6 +277,16 @@ defmodule Money.ExchangeRates.RetrieverTest do
     # Synchronise on init having fully run (including any self-sent messages).
     _ = :sys.get_state(pid)
     {name, pid}
+  end
+
+  describe "backwards compatibility with a legacy singleton cache module" do
+    test "latest_rates and historic_rates still work against an old, arity-0 cache module" do
+      config = %{Money.ExchangeRates.default_config() | cache_module: LegacyCacheMock}
+      {name, _pid} = start_named(config)
+
+      assert {:ok, %{USD: _}} = Retriever.latest_rates(name)
+      assert {:ok, _rates} = Retriever.historic_rates(name, ~D[2017-01-01])
+    end
   end
 
   describe "startup scheduling and preload" do

--- a/test/money/exchange_rates/retriever_test.exs
+++ b/test/money/exchange_rates/retriever_test.exs
@@ -296,30 +296,36 @@ defmodule Money.ExchangeRates.RetrieverTest do
       {:ok, registry: registry}
     end
 
-    test "boots and serves latest and historic rates through its cache", %{registry: registry} do
-      name = {:via, Registry, {registry, :bid}}
-      pid = start_supervised!({Retriever, name: name}, id: :via_bid)
-      _ = :sys.get_state(pid)
+    test "the public lookup API accepts the {:via, ...} name", %{registry: registry} do
+      name = {:via, Registry, {registry, :rates}}
+      pid = start_supervised!({Retriever, name: name}, id: :retriever_rates)
 
       assert GenServer.whereis(name) == pid
 
-      assert {:ok, %{USD: _}} = GenServer.call(pid, :latest_rates)
+      refute Retriever.latest_rates_available?(name)
 
-      assert {:ok, %{AUD: Decimal.new("0.5"), EUR: Decimal.new("1.1"), USD: Decimal.new("0.7")}} ==
-               GenServer.call(pid, {:historic_rates, ~D[2017-01-01]})
+      assert {:ok, %{USD: _}} = Retriever.latest_rates(name)
+      assert Retriever.latest_rates_available?(name)
+      assert {:ok, %DateTime{}} = Retriever.last_updated(name)
+
+      assert Retriever.historic_rates(name, ~D[2017-01-01]) ==
+               {:ok, %{AUD: Decimal.new("0.5"), EUR: Decimal.new("1.1"), USD: Decimal.new("0.7")}}
+
+      assert [{:ok, _}, {:ok, _}] =
+               Retriever.historic_rates(name, ~D[2017-01-01], ~D[2017-01-02])
     end
 
     test "keeps its cache isolated from another named retriever", %{registry: registry} do
-      bid = start_supervised!({Retriever, name: {:via, Registry, {registry, :bid}}}, id: :via_bid)
-      ask = start_supervised!({Retriever, name: {:via, Registry, {registry, :ask}}}, id: :via_ask)
-      _ = :sys.get_state(bid)
-      _ = :sys.get_state(ask)
+      foo = {:via, Registry, {registry, :foo}}
+      bar = {:via, Registry, {registry, :bar}}
+      start_supervised!({Retriever, name: foo}, id: :retriever_foo)
+      start_supervised!({Retriever, name: bar}, id: :retriever_bar)
 
-      # Populate only the bid retriever's cache; the ask retriever must not see it.
-      assert {:ok, _rates} = GenServer.call(bid, :latest_rates)
+      # Populate only the foo retriever's cache; the bar retriever must not see it.
+      assert {:ok, _rates} = Retriever.latest_rates(foo)
 
-      assert GenServer.call(bid, :latest_rates_available?)
-      refute GenServer.call(ask, :latest_rates_available?)
+      assert Retriever.latest_rates_available?(foo)
+      refute Retriever.latest_rates_available?(bar)
     end
   end
 

--- a/test/money/exchange_rates/retriever_test.exs
+++ b/test/money/exchange_rates/retriever_test.exs
@@ -289,6 +289,40 @@ defmodule Money.ExchangeRates.RetrieverTest do
     end
   end
 
+  describe "a retriever registered under a non-atom name" do
+    setup do
+      registry = :"via_registry_#{System.unique_integer([:positive])}"
+      start_supervised!({Registry, keys: :unique, name: registry})
+      {:ok, registry: registry}
+    end
+
+    test "boots and serves latest and historic rates through its cache", %{registry: registry} do
+      name = {:via, Registry, {registry, :bid}}
+      pid = start_supervised!({Retriever, name: name}, id: :via_bid)
+      _ = :sys.get_state(pid)
+
+      assert GenServer.whereis(name) == pid
+
+      assert {:ok, %{USD: _}} = GenServer.call(pid, :latest_rates)
+
+      assert {:ok, %{AUD: Decimal.new("0.5"), EUR: Decimal.new("1.1"), USD: Decimal.new("0.7")}} ==
+               GenServer.call(pid, {:historic_rates, ~D[2017-01-01]})
+    end
+
+    test "keeps its cache isolated from another named retriever", %{registry: registry} do
+      bid = start_supervised!({Retriever, name: {:via, Registry, {registry, :bid}}}, id: :via_bid)
+      ask = start_supervised!({Retriever, name: {:via, Registry, {registry, :ask}}}, id: :via_ask)
+      _ = :sys.get_state(bid)
+      _ = :sys.get_state(ask)
+
+      # Populate only the bid retriever's cache; the ask retriever must not see it.
+      assert {:ok, _rates} = GenServer.call(bid, :latest_rates)
+
+      assert GenServer.call(bid, :latest_rates_available?)
+      refute GenServer.call(ask, :latest_rates_available?)
+    end
+  end
+
   describe "startup scheduling and preload" do
     test "a retrieval interval logs the init message and fetches on demand" do
       config = %{

--- a/test/money/exchange_rates_test.exs
+++ b/test/money/exchange_rates_test.exs
@@ -2,7 +2,6 @@ defmodule Money.ExchangeRatesTest do
   use ExUnit.Case, async: false
 
   alias Money.ExchangeRates
-  alias Money.ExchangeRates.Cache.Ets
 
   doctest ExchangeRates
 
@@ -26,9 +25,15 @@ defmodule Money.ExchangeRatesTest do
 
   describe "latest_rates/0" do
     test "fetches from the cache when rates are cached" do
-      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, DateTime.utc_now())
+      pid = Process.whereis(Money.ExchangeRates.Retriever)
+      assert {:ok, rates} = ExchangeRates.latest_rates()
 
-      assert ExchangeRates.latest_rates() == {:ok, @rates}
+      trace_module(pid, Money.ExchangeRatesCallbackMock)
+
+      assert ExchangeRates.latest_rates() == {:ok, rates}
+
+      refute_received {:trace, ^pid, :call,
+                       {Money.ExchangeRatesCallbackMock, :latest_rates_retrieved, _}}
     end
 
     test "fetches from the retriever when the cache is empty" do
@@ -45,7 +50,7 @@ defmodule Money.ExchangeRatesTest do
     end
 
     test "returns error when retriever stops even if cache has rates" do
-      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, DateTime.utc_now())
+      assert {:ok, _rates} = ExchangeRates.latest_rates()
       stop_supervised(Money.ExchangeRates.Retriever)
 
       assert ExchangeRates.latest_rates() ==
@@ -67,9 +72,15 @@ defmodule Money.ExchangeRatesTest do
 
   describe "historic_rates/1" do
     test "fetches from the cache when rates are cached" do
-      Ets.store_historic_rates(Money.ExchangeRates.Retriever, @rates, ~D[2017-01-01])
+      pid = Process.whereis(Money.ExchangeRates.Retriever)
+      assert {:ok, rates} = ExchangeRates.historic_rates(~D[2017-01-01])
 
-      assert ExchangeRates.historic_rates(~D[2017-01-01]) == {:ok, @rates}
+      trace_module(pid, Money.ExchangeRatesCallbackMock)
+
+      assert ExchangeRates.historic_rates(~D[2017-01-01]) == {:ok, rates}
+
+      refute_received {:trace, ^pid, :call,
+                       {Money.ExchangeRatesCallbackMock, :historic_rates_retrieved, _}}
     end
 
     test "fetches from the retriever when the cache is empty" do
@@ -85,7 +96,7 @@ defmodule Money.ExchangeRatesTest do
     end
 
     test "returns error when retriever stops even if cache has rates" do
-      Ets.store_historic_rates(Money.ExchangeRates.Retriever, @rates, ~D[2017-01-01])
+      assert {:ok, _rates} = ExchangeRates.historic_rates(~D[2017-01-01])
       stop_supervised(Money.ExchangeRates.Retriever)
 
       assert ExchangeRates.historic_rates(~D[2017-01-01]) ==
@@ -106,7 +117,7 @@ defmodule Money.ExchangeRatesTest do
 
   describe "latest_rates_available?/0" do
     test "returns true when rates are in the cache" do
-      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, DateTime.utc_now())
+      assert {:ok, _rates} = ExchangeRates.latest_rates()
 
       assert ExchangeRates.latest_rates_available?()
     end
@@ -122,7 +133,7 @@ defmodule Money.ExchangeRatesTest do
     end
 
     test "returns false when retriever stops even if cache has rates" do
-      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, DateTime.utc_now())
+      assert {:ok, _rates} = ExchangeRates.latest_rates()
       stop_supervised(Money.ExchangeRates.Retriever)
 
       refute ExchangeRates.latest_rates_available?()
@@ -131,10 +142,11 @@ defmodule Money.ExchangeRatesTest do
 
   describe "last_updated/0" do
     test "returns the time when rates have been stored" do
-      retrieved_at = DateTime.utc_now(:second)
-      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, retrieved_at)
+      before_fetch = DateTime.utc_now()
+      assert {:ok, _rates} = ExchangeRates.latest_rates()
 
-      assert ExchangeRates.last_updated() == {:ok, retrieved_at}
+      assert {:ok, retrieved_at} = ExchangeRates.last_updated()
+      assert DateTime.compare(retrieved_at, before_fetch) != :lt
     end
 
     test "returns an error when the retriever is not running" do
@@ -146,8 +158,7 @@ defmodule Money.ExchangeRatesTest do
     end
 
     test "returns error when retriever stops even if timestamp is cached" do
-      retrieved_at = DateTime.utc_now(:second)
-      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, retrieved_at)
+      assert {:ok, _rates} = ExchangeRates.latest_rates()
       stop_supervised(Money.ExchangeRates.Retriever)
 
       assert ExchangeRates.last_updated() ==

--- a/test/money/exchange_rates_test.exs
+++ b/test/money/exchange_rates_test.exs
@@ -26,7 +26,7 @@ defmodule Money.ExchangeRatesTest do
 
   describe "latest_rates/0" do
     test "fetches from the cache when rates are cached" do
-      Ets.store_latest_rates(@rates, DateTime.utc_now())
+      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, DateTime.utc_now())
 
       assert ExchangeRates.latest_rates() == {:ok, @rates}
     end
@@ -45,7 +45,7 @@ defmodule Money.ExchangeRatesTest do
     end
 
     test "returns error when retriever stops even if cache has rates" do
-      Ets.store_latest_rates(@rates, DateTime.utc_now())
+      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, DateTime.utc_now())
       stop_supervised(Money.ExchangeRates.Retriever)
 
       assert ExchangeRates.latest_rates() ==
@@ -67,7 +67,7 @@ defmodule Money.ExchangeRatesTest do
 
   describe "historic_rates/1" do
     test "fetches from the cache when rates are cached" do
-      Ets.store_historic_rates(@rates, ~D[2017-01-01])
+      Ets.store_historic_rates(Money.ExchangeRates.Retriever, @rates, ~D[2017-01-01])
 
       assert ExchangeRates.historic_rates(~D[2017-01-01]) == {:ok, @rates}
     end
@@ -85,7 +85,7 @@ defmodule Money.ExchangeRatesTest do
     end
 
     test "returns error when retriever stops even if cache has rates" do
-      Ets.store_historic_rates(@rates, ~D[2017-01-01])
+      Ets.store_historic_rates(Money.ExchangeRates.Retriever, @rates, ~D[2017-01-01])
       stop_supervised(Money.ExchangeRates.Retriever)
 
       assert ExchangeRates.historic_rates(~D[2017-01-01]) ==
@@ -106,7 +106,7 @@ defmodule Money.ExchangeRatesTest do
 
   describe "latest_rates_available?/0" do
     test "returns true when rates are in the cache" do
-      Ets.store_latest_rates(@rates, DateTime.utc_now())
+      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, DateTime.utc_now())
 
       assert ExchangeRates.latest_rates_available?()
     end
@@ -122,7 +122,7 @@ defmodule Money.ExchangeRatesTest do
     end
 
     test "returns false when retriever stops even if cache has rates" do
-      Ets.store_latest_rates(@rates, DateTime.utc_now())
+      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, DateTime.utc_now())
       stop_supervised(Money.ExchangeRates.Retriever)
 
       refute ExchangeRates.latest_rates_available?()
@@ -132,7 +132,7 @@ defmodule Money.ExchangeRatesTest do
   describe "last_updated/0" do
     test "returns the time when rates have been stored" do
       retrieved_at = DateTime.utc_now(:second)
-      Ets.store_latest_rates(@rates, retrieved_at)
+      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, retrieved_at)
 
       assert ExchangeRates.last_updated() == {:ok, retrieved_at}
     end
@@ -147,7 +147,7 @@ defmodule Money.ExchangeRatesTest do
 
     test "returns error when retriever stops even if timestamp is cached" do
       retrieved_at = DateTime.utc_now(:second)
-      Ets.store_latest_rates(@rates, retrieved_at)
+      Ets.store_latest_rates(Money.ExchangeRates.Retriever, @rates, retrieved_at)
       stop_supervised(Money.ExchangeRates.Retriever)
 
       assert ExchangeRates.last_updated() ==


### PR DESCRIPTION
Hey @kipcole9, here is my attempt to have different cache modules per retriever, instead of a singleton shared one, addressing https://github.com/ex-money/money/pull/201#issuecomment-4805600596.

Let me know what you think of it.