### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ No backend module is required. Localize uses runtime locale resolution. Configur
 ```elixir
 config :localize,
   default_locale: :en,
-  preload_locales: [:en, :fr, :zh]
+  supported_locales: [:en, :fr, :zh]
 ```
 
 The current locale can be set at runtime:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ config :ex_cldr, default_backend: MyApp.Cldr
 # Optionally configure localize locales:
 config :localize,
   default_locale: :en,
-  preload_locales: [:en, :fr, :de]
+  supported_locales: [:en, :fr, :de]
 ```
 
 ### Remove `:backend` option from function calls


### PR DESCRIPTION
use supported_locales because the :preload_locales configuration key is deprecated and ignored