### PR TITLE
fix: fall back to CLDR digits when iso_digits is nil

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -2934,8 +2934,8 @@ defmodule Money do
     end
   end
 
-  defp do_digits_from_options(currency_data, :iso), do: Map.fetch(currency_data, :iso_digits)
-  defp do_digits_from_options(currency_data, nil), do: Map.fetch(currency_data, :iso_digits)
+  defp do_digits_from_options(currency_data, :iso), do: iso_digits_from_currency(currency_data)
+  defp do_digits_from_options(currency_data, nil), do: iso_digits_from_currency(currency_data)
   defp do_digits_from_options(currency_data, :cash), do: Map.fetch(currency_data, :cash_digits)
   defp do_digits_from_options(currency_data, :accounting), do: Map.fetch(currency_data, :digits)
 
@@ -2944,6 +2944,10 @@ defmodule Money do
 
   defp do_digits_from_options(_currency_data, other),
     do: {:error, invalid_digits_error(other)}
+
+  # Some historic currencies may have no ISO 4217 digit definition
+  defp iso_digits_from_currency(%{iso_digits: nil, digits: d}), do: {:ok, d}
+  defp iso_digits_from_currency(currency_data), do: Map.fetch(currency_data, :iso_digits)
 
   defp invalid_digits_error(other),
     do:

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -404,6 +404,10 @@ defmodule MoneyTest do
              Money.new(:CHF, "123.45")
   end
 
+  test "Money is rounded for historic currencies" do
+    assert Money.round(Money.new(:BGN, "12.346")) == Money.new(:BGN, "12.35")
+  end
+
   test "Extract decimal from money" do
     assert Money.to_decimal(Money.new(:USD, 1234)) == Decimal.new(1234)
   end
@@ -715,6 +719,8 @@ defmodule MoneyTest do
              {:error,
               {Money.InvalidDigitsError,
                "Unknown or invalid :currency_digits option, found: :rubbish"}}
+
+    assert Money.from_integer(1234, :BGN) == Money.new(:BGN, "12.34")
   end
 
   if Version.compare(System.version(), "1.18.0") in [:gt, :eq] do


### PR DESCRIPTION
Hello, and thanks for a great library <3

We recently upgraded a very big codebase to ex_money 6 (from 5), and noticed this behavior:

Historic currencies (like BGN) have nil `iso_digits` in localize. So using a historic currency would crash `Money.from_integer` and `Money.round`.

This fix falls back to using `digits` in these cases.

Let me know what you think!